### PR TITLE
🐛 修复二维码登录

### DIFF
--- a/gsuid_core/utils/cookie_manager/qrlogin.py
+++ b/gsuid_core/utils/cookie_manager/qrlogin.py
@@ -157,8 +157,8 @@ async def qrcode_login(bot: Bot, ev: Event, user_id: str) -> str:
             im = '[登录]请求失败, 请稍后再试...'
             return await send_msg(im)
 
-        uid_bind_list = await sqla.get_bind_uid_list(user_id)
-        sruid_bind_list = await sqla.get_bind_sruid_list(user_id)
+        uid_bind_list = await sqla.get_bind_uid_list(user_id) or []
+        sruid_bind_list = await sqla.get_bind_sruid_list(user_id) or []
         # 没有在gsuid绑定uid的情况
         if not (uid_bind_list or sruid_bind_list):
             logger.warning('[登录]game_token获取失败')


### PR DESCRIPTION
![9fc2c5c5f51af63a3c59af006fa6653f](https://github.com/Genshin-bots/gsuid_core/assets/98764734/0f3bd3aa-99e5-43f7-9c98-5f683e04bb45)
修复在没有绑定uid（原神），但绑定了sruid（星铁）的情况下，由于uid_bind_list为NoneType不可迭代导致的报错，无法正常获取CK的问题