### PR TITLE
修改dockerfile和docker-compose文件，使生成镜像变为真正可独立部署镜像

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,31 @@
-FROM swr.cn-north-4.myhuaweicloud.com/ddn-k8s/docker.io/library/python:3.10-slim-bullseye
-
-ENV TZ=Asia/Shanghai
+# 基准镜像更新版本至官方文档推荐版本：3.12
+FROM m.daocloud.io/docker.io/library/python:3.12-slim-bullseye
 
 WORKDIR /app/gsuid_core
-
+# 暴露 8765 端口
+EXPOSE 8765
 ENV PATH="${PATH}:/root/.local/bin"
+ENV TZ=Asia/Shanghai
 
-ADD ./ /app/
-
-RUN sed -i 's/http:\/\/deb.debian.org/http:\/\/ftp.cn.debian.org/g' /etc/apt/sources.list \
+# 调整层顺序，这些安装是固定的，单独分层
+RUN echo build start ---------------------------- \
+&& mv \
+    && sed -i 's/http:\/\/deb.debian.org/http:\/\/ftp.cn.debian.org/g' /etc/apt/sources.list \
     && sed -i 's/http:\/\/security.debian.org/http:\/\/mirrors.ustc.edu.cn/g' /etc/apt/sources.list \
     && apt-get update -y \
-    && apt-get upgrade -y \
     && apt install curl git -y \
     && apt-get autoremove \
     && apt-get clean \
-    && cp /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && pip install --no-cache-dir --upgrade pip -i https://mirror.nju.edu.cn/pypi/web/simple/ \
-    && pip install uv -i https://mirror.nju.edu.cn/pypi/web/simple/ \
-    && uv sync \
-    && rm -rf /app/*
+    && pip install uv -i https://mirror.nju.edu.cn/pypi/web/simple/
 
-CMD uv run core
+# 下面的内容与项目代码相关，有可能变换，单独分层
+ADD ./ /app/
+RUN uv sync \
+    && echo build end ----------------------------
+# 不需要删除 WORKDIR 中的内容，这是主程序所在的文件夹
+# && rm -rf /app/*
+
+# 使用传入的 TZ 环境变量设定时间和时区，默认为 Asia/Shanghai
+CMD cp /usr/share/zoneinfo/$TZ /etc/localtime; echo $TZ > /etc/timezone && \
+    uv run core

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ git clone -b v4 https://github.com/KimigaiiWuyi/GenshinUID.git --depth=1 --singl
 docker-compose up -d --build
 
 # 之后的部署配置，仅修改 docker-compose.yaml 文件，需执行以下指令：
+# 先停止相关容器
+docker-compose down
+# 再按照新的配置部署新的容器
 docker-compose up -d
 ```
 
@@ -86,13 +89,26 @@ services:
       - 18765:8765 # 端口映射：原插件的 8765 对应容器外部的 18765 端口
     volumes:
     # 仅映射需要外部访问的文件夹，如 data、plugins 文件夹
-	# 以下例子：将容器内插件的 data、plugins 文件夹，映射到 /opt/gscore_data 和 /opt/gscore_plugins 中
+	# 以下例子：将容器内 core 程序的 data、plugins 文件夹，映射到 /opt/gscore_data 和 /opt/gscore_plugins 中
       - /opt/gscore_data:/app/gsuid_core/data
       - /opt/gscore_plugins:/app/gsuid_core/plugins
 ```
 5. 容器部署的相关使用说明
-- 如需访问容器部署的 core 根目录，需要通过`docker exec -it <容器id> bash`进入，进入后默认的`/app/gsuid_core`对应文档中的 core 根目录`gsuid_core`
-- 默认 core 运行在`localhost:8765`端口上，Docker 部署后必须修改`config.json`文件（对应上面第 4 点中配置，在外部的地址为`/opt/gscore_data/config.json`，需将其中的`port`配置修改为`0.0.0.0:8765`
-- 关于端口配置，由于 docker 容器本身会对端口做转发（对应 yaml 文件中的`port`部分，因此建议使用 docker compose 的相关配置或 docker 指令来修改端口，而不用 core 本身的配置来修改，同时每次 docker 修改端口后都需要重新执行 docker compose 启动）
+- 如需访问容器部署的 core 的其他路径（上面 yaml 文件中没有映射的文件或路径）则需要通过`docker exec -it <容器id> bash`进入，进入后默认的`/app/gsuid_core`对应文档中的 core 根目录`gsuid_core`
+
+- 默认 core 运行在`localhost:8765`端口上，Docker 部署后无法连接
+
+  必须修改`config.json`文件中的`HOST`配置，参考 [https://docs.sayu-bot.com/Started/CoreConfig.html](https://docs.sayu-bot.com/Started/CoreConfig.html)
+
+  （以上面的 yaml 文件为例，配置文件在文档中的路径为`gsuid_core/data`，则对应在容器外部的地址为`/opt/gscore_data/config.json`，需将其中的`port`配置修改为`0.0.0.0:8765`
+
+  然后执行`docker restart <容器id>`重启容器
+
+
+- 关于端口配置，由于 docker 容器本身会对端口做转发（对应 yaml 文件中的`port`部分，因此建议使用 docker compose 的相关配置或 docker 指令来修改端口，而不用 core 本身的配置来修改
+
+	同时每次 docker 修改端口后都需要先删除当前容器重新执行`docker compose up -d`指令重新部署
+
 - 如需增加插件，则需要进入容器项目根目录，按照官方教程使用命令安装或手动安装
+
 - 如果Bot（例如 NoneBot2、HoshinoBot）也是Docker部署的，Core或其插件更新后，可能需要将Core和Bot的容器都重启才生效

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,15 @@
 services:
   gsuid-core:
-    build: .
+    build:
+      context: .
     container_name: gsuidcore
-    restart: always
+    restart: unless-stopped
     environment:
       - TZ=Asia/Shanghai
     ports:
       - 8765:8765
     volumes:
-      - ${PWD}:/app
+    # 仅映射需要的文件夹，如果映射所有文件夹则容器内的文件会被覆盖
+    # 如需访问这种方式部署的项目根目录，需要通过 docker exec -it <容器id> bash 进入，进入后默认的 /app/gsuid_core 即为插件根目录
+      - /opt/gscore_data:/gsuid_core/data
+      - /opt/gscore_plugins:/gsuid_core/plugins

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - TZ=Asia/Shanghai
     ports:
-      - 8765:8765
+      - 18765:8765
     volumes:
     # 仅映射需要的文件夹，如果映射所有文件夹则容器内的文件会被覆盖
     # 如需访问这种方式部署的项目根目录，需要通过 docker exec -it <容器id> bash 进入，进入后默认的 /app/gsuid_core 即为插件根目录


### PR DESCRIPTION
1. 目前示例中的提供的代码，构建出的镜像需要在原 git 文件夹中的特定路径下才能使用，个人认为不是真正的可以“一次开发，处处部署”的真镜像
2. 因此修改了 dockerfile 和 docker-compose.yaml 文件，将软件需要的所有依赖和 python 环境通通打包（但不包含 Bot 和插件），可以实现单镜像在任意电脑上运行完整的 core 核心服务
3. 同时修改了说明文档，补充了容器部署的一些常见问题