### PR TITLE
✨ 新增核心配置/插件/命令的查看与设置命令

### DIFF
--- a/gsuid_core/buildin_plugins/core_command/core_config_cmd/__init__.py
+++ b/gsuid_core/buildin_plugins/core_command/core_config_cmd/__init__.py
@@ -1,0 +1,237 @@
+"""
+查看配置                          → 列出所有可配置插件
+查看配置 <插件名>                  → 展示该插件所有配置项
+查看配置 <插件名> <键>             → 查看某一项的详情
+设置配置 <插件名> <键> <值>        → 设置配置项
+查看插件                          → 列出所有已加载插件
+查看插件 <插件名>                  → 查看插件详情
+设置插件 <插件名> <参数> <值>      → 设置插件属性
+查看命令                          → 列出所有命令(SV)
+查看命令 <插件名>                  → 列出该插件下所有命令
+查看命令 <命令名>                  → 查看命令详情
+设置命令 <命令名> <参数> <值>      → 设置命令属性
+"""
+
+from gsuid_core.sv import SL, SV
+from gsuid_core.bot import Bot
+from gsuid_core.models import Event
+
+from ._render import (
+    fmt_val,
+    is_skip_type,
+    render_sv_list,
+    render_sv_detail,
+    render_config_list,
+    render_plugin_list,
+    render_config_items,
+    render_config_detail,
+    render_plugin_detail,
+)
+from ._setter import (
+    SV_AREA,
+    SV_PARAMS,
+    PLUGIN_AREA,
+    PLUGIN_EXTRA,
+    PLUGIN_PARAMS,
+    apply_set,
+    set_config_val,
+)
+from ._resolve import (
+    hint,
+    prefix,
+    resolve_sv,
+    plugin_configs,
+    resolve_plugin,
+    all_config_names,
+    find_config_item,
+    match_config_name,
+)
+
+sv_core_config_cmd = SV("Core配置命令", pm=0)
+
+
+async def _resolve_config_name(raw: str):
+    """先精确匹配配置名, 失败则用别名解析第一个词"""
+    matched = match_config_name(raw)
+    if matched:
+        return matched
+    first, *remaining = raw.split(None, 1)
+    resolved = await resolve_plugin(first)
+    if resolved and plugin_configs(resolved):
+        return resolved, (remaining[0] if remaining else "")
+    return None
+
+
+# ── 配置 ─────────────────────────────────────────────────
+
+
+@sv_core_config_cmd.on_command("查看配置", block=True)
+async def show_config(bot: Bot, ev: Event):
+    raw = ev.text.strip()
+
+    p = prefix()
+    if not raw:
+        names = sorted(all_config_names())
+        if not names:
+            await bot.send("暂无可配置插件")
+            return
+        msg = f"提示: {p}查看配置 <插件名>\n\n"
+        await bot.send(msg + render_config_list(names))
+        return
+
+    matched = await _resolve_config_name(raw)
+    if matched is None:
+        await bot.send(f"未找到 [{raw}] 的配置, {hint('查看配置')}")
+        return
+
+    plugin_name, rest = matched
+
+    if not rest:
+        msg = f"提示: {p}查看配置 {plugin_name} <键>\n\n"
+        await bot.send(msg + render_config_items(plugin_name, plugin_configs(plugin_name)))
+        return
+
+    result = find_config_item(plugin_name, rest)
+    if result is None:
+        await bot.send(f"未找到配置项 [{rest}], {hint(f'查看配置 {plugin_name}')}")
+        return
+
+    cfg, item = result
+    if is_skip_type(item):
+        await bot.send(f"[{plugin_name}] {rest} 为 Dict/Image 类型, 请使用 WebConsole 修改")
+        return
+    msg = f"提示: {p}设置配置 {plugin_name} {rest} <值>\n\n"
+    await bot.send(msg + render_config_detail(plugin_name, rest, cfg, item))
+
+
+@sv_core_config_cmd.on_command("设置配置", block=True)
+async def set_config(bot: Bot, ev: Event):
+    raw = ev.text.strip()
+
+    if not raw:
+        await bot.send(f"格式: {prefix()}设置配置 <插件名> <配置键> <值>")
+        return
+
+    matched = await _resolve_config_name(raw)
+    if matched is None:
+        await bot.send(f"未找到配置, {hint('查看配置')}")
+        return
+
+    plugin_name, rest = matched
+    parts = rest.split(None, 1)
+    if len(parts) < 2:
+        await bot.send(f"格式: {prefix()}设置配置 <插件名> <配置键> <值>")
+        return
+
+    key, raw_value = parts
+    found = find_config_item(plugin_name, key)
+    if found is None:
+        await bot.send(f"未找到配置项 [{key}]")
+        return
+
+    cfg, _ = found
+    await bot.send(set_config_val(cfg, plugin_name, key, raw_value, is_skip_type, fmt_val))
+
+
+# ── 插件 ─────────────────────────────────────────────────
+
+
+@sv_core_config_cmd.on_command("查看插件", block=True)
+async def show_plugin(bot: Bot, ev: Event):
+    raw = ev.text.strip()
+
+    p = prefix()
+    if not raw:
+        msg = f"提示: {p}查看插件 <插件名>\n\n"
+        await bot.send(msg + render_plugin_list())
+        return
+
+    plugin_name = await resolve_plugin(raw)
+    if plugin_name is None:
+        await bot.send(f"未找到插件 [{raw}], {hint('查看插件')}")
+        return
+
+    detail = render_plugin_detail(plugin_name, SL.plugins[plugin_name])
+    tip = f"\n\n提示: {p}设置插件 {plugin_name} <参数> <值>\n可用参数: {PLUGIN_PARAMS}"
+    await bot.send(detail + tip)
+
+
+@sv_core_config_cmd.on_command("设置插件", block=True)
+async def set_plugin(bot: Bot, ev: Event):
+    args = ev.text.strip().split(None, 2)
+    if len(args) < 3:
+        await bot.send(f"格式: {prefix()}设置插件 <插件名> <参数> <值>\n可用参数: {PLUGIN_PARAMS}")
+        return
+
+    raw_plugin, param, raw_value = args
+    plugin_name = await resolve_plugin(raw_plugin)
+    if plugin_name is None:
+        await bot.send(f"未找到插件 [{raw_plugin}]")
+        return
+
+    await bot.send(
+        apply_set(
+            SL.plugins[plugin_name],
+            f"插件 [{plugin_name}]",
+            param,
+            raw_value,
+            PLUGIN_AREA,
+            PLUGIN_PARAMS,
+            PLUGIN_EXTRA,
+        )
+    )
+
+
+# ── 命令 ─────────────────────────────────────────────────
+
+
+@sv_core_config_cmd.on_command("查看命令", block=True)
+async def show_sv(bot: Bot, ev: Event):
+    raw = ev.text.strip()
+
+    p = prefix()
+    if not raw:
+        msg = f"提示: {p}查看命令 <命令名>\n\n"
+        await bot.send(msg + render_sv_list())
+        return
+
+    sv_name, sv = resolve_sv(raw)
+    if sv is not None:
+        detail = render_sv_detail(sv)
+        tip = f"\n\n提示: {p}设置命令 {sv_name} <参数> <值>\n可用参数: {SV_PARAMS}"
+        await bot.send(detail + tip)
+        return
+
+    # 尝试按插件名过滤
+    plugin_name = await resolve_plugin(raw)
+    if plugin_name and any(sv.self_plugin_name == plugin_name for sv in SL.lst.values()):
+        msg = f"提示: {p}查看命令 <命令名> 查看详情\n\n"
+        await bot.send(msg + render_sv_list(plugin_name))
+        return
+
+    await bot.send(f"未找到命令或插件 [{raw}], {hint('查看命令')}")
+
+
+@sv_core_config_cmd.on_command("设置命令", block=True)
+async def set_sv(bot: Bot, ev: Event):
+    args = ev.text.strip().split(None, 2)
+    if len(args) < 3:
+        await bot.send(f"格式: {prefix()}设置命令 <命令名> <参数> <值>\n可用参数: {SV_PARAMS}")
+        return
+
+    sv_name, param, raw_value = args
+    sv_name, sv = resolve_sv(sv_name)
+    if sv is None:
+        await bot.send(f"未找到命令 [{sv_name}]")
+        return
+
+    await bot.send(
+        apply_set(
+            sv,
+            f"命令 [{sv_name}]",
+            param,
+            raw_value,
+            SV_AREA,
+            SV_PARAMS,
+        )
+    )

--- a/gsuid_core/buildin_plugins/core_command/core_config_cmd/_render.py
+++ b/gsuid_core/buildin_plugins/core_command/core_config_cmd/_render.py
@@ -1,0 +1,113 @@
+from typing import List
+
+from gsuid_core.sv import SL
+from gsuid_core.utils.plugins_config.models import (
+    GSC,
+    GsBoolConfig,
+    GsDictConfig,
+    GsImageConfig,
+    GsTimeRConfig,
+)
+from gsuid_core.utils.plugins_config.gs_config import StringConfig
+
+_SENSITIVE_KEYS = {"token", "key", "secret", "password", "密钥", "口令", "apikey", "api_key"}
+_SKIP_TYPES = (GsDictConfig, GsImageConfig)
+
+
+def is_skip_type(item) -> bool:
+    return isinstance(item, _SKIP_TYPES)
+
+
+def _join(lst) -> str:
+    return ", ".join(str(i) for i in lst) if lst else "无"
+
+
+def fmt_val(item: GSC, key: str = "") -> str:
+    """格式化配置项的值, 敏感字段脱敏"""
+    if isinstance(item, GsBoolConfig):
+        return "开启" if item.data else "关闭"
+    if isinstance(item, GsTimeRConfig):
+        return f"{item.data[0]:02d}:{item.data[1]:02d}"
+    val = str(item.data)
+    if key and val and any(s in key.lower() for s in _SENSITIVE_KEYS):
+        return val[:2] + "****" + val[-2:] if len(val) > 4 else "****"
+    return val
+
+
+def render_config_list(names: List[str]) -> str:
+    return "可配置插件列表:\n" + "\n".join(f"  · {n}" for n in names)
+
+
+def render_config_items(plugin_name: str, configs: dict) -> str:
+    lines = [f"[{plugin_name}] 配置项:"]
+    for cfg_name, cfg in configs.items():
+        lines.append(f"\n  ── {cfg_name} ──")
+        for key, item in cfg.config.items():
+            if isinstance(item, _SKIP_TYPES):
+                tag = "Dict" if isinstance(item, GsDictConfig) else "Image"
+                lines.append(f"  {key}  [{tag}]  {item.title}  (请使用WebConsole修改)")
+            else:
+                tag = type(item).__name__.replace("Gs", "").replace("Config", "")
+                lines.append(f"  {key}  [{tag}]  {item.title}  = {fmt_val(item, key)}")
+    return "\n".join(lines)
+
+
+def render_config_detail(plugin_name: str, key: str, cfg: StringConfig, item: GSC) -> str:
+    return (
+        f"[{plugin_name}] {key}\n"
+        f"  配置组: {cfg.config_name}\n"
+        f"  标题: {item.title}\n"
+        f"  描述: {item.desc}\n"
+        f"  类型: {type(item).__name__}\n"
+        f"  当前值: {fmt_val(item, key)}"
+    )
+
+
+def render_plugin_list() -> str:
+    lines = ["已加载插件列表:"]
+    for name, p in sorted(SL.plugins.items()):
+        status = "ON" if p.enabled else "OFF"
+        alias = f"  ({', '.join(p.alias)})" if p.alias else ""
+        lines.append(f"  [{status}] {name}  pm={p.pm}{alias}")
+    return "\n".join(lines)
+
+
+def render_plugin_detail(plugin_name: str, p) -> str:
+    return "\n".join(
+        [
+            f"插件 [{plugin_name}]",
+            f"  状态: {'开启' if p.enabled else '关闭'}  权限: {p.pm}  优先级: {p.priority}",
+            f"  作用范围: {p.area}",
+            f"  别名: {_join(p.alias)}",
+            f"  前缀: {_join(p.prefix)}",
+            f"  强制前缀: {_join(p.force_prefix)}",
+            f"  黑名单: {_join(p.black_list)}",
+            f"  白名单: {_join(p.white_list)}",
+        ]
+    )
+
+
+def render_sv_list(plugin_name: str = "") -> str:
+    if plugin_name:
+        lines = [f"[{plugin_name}] 命令列表:"]
+        for name, sv in sorted(SL.lst.items()):
+            if sv.self_plugin_name == plugin_name:
+                status = "ON" if sv.enabled else "OFF"
+                lines.append(f"  [{status}] {name}  pm={sv.pm}")
+        return "\n".join(lines)
+    lines = ["已加载命令列表:"]
+    for name, sv in sorted(SL.lst.items()):
+        status = "ON" if sv.enabled else "OFF"
+        lines.append(f"  [{status}] {name}  pm={sv.pm}  ({sv.self_plugin_name})")
+    return "\n".join(lines)
+
+
+def render_sv_detail(sv) -> str:
+    return (
+        f"命令 [{sv.name}]\n"
+        f"  所属插件: {sv.self_plugin_name}\n"
+        f"  状态: {'开启' if sv.enabled else '关闭'}  权限: {sv.pm}  优先级: {sv.priority}\n"
+        f"  作用范围: {sv.area}\n"
+        f"  黑名单: {_join(sv.black_list)}\n"
+        f"  白名单: {_join(sv.white_list)}"
+    )

--- a/gsuid_core/buildin_plugins/core_command/core_config_cmd/_resolve.py
+++ b/gsuid_core/buildin_plugins/core_command/core_config_cmd/_resolve.py
@@ -1,0 +1,87 @@
+from typing import Dict, Optional
+
+from gsuid_core.sv import SL, get_plugin_available_prefix
+from gsuid_core.utils.plugins_update.api import PLUGINS_PATH
+from gsuid_core.utils.plugins_update._plugins import plugins_list, refresh_list
+from gsuid_core.utils.plugins_config.gs_config import StringConfig, all_config_list
+
+
+def prefix() -> str:
+    return get_plugin_available_prefix("core_command")
+
+
+def hint(cmd: str) -> str:
+    return f"发送 [{prefix()}{cmd}]"
+
+
+async def resolve_plugin(name: str) -> Optional[str]:
+    """将输入(插件名或别名)解析为 SL.plugins 中的 key"""
+    if name in SL.plugins:
+        return name
+    lo = name.lower()
+    for key, p in SL.plugins.items():
+        if key.lower() == lo or any(a.lower() == lo for a in p.alias):
+            return key
+
+    if not plugins_list:
+        await refresh_list()
+    for _n, plugin in plugins_list.items():
+        if "alias" in plugin:
+            for alias in plugin["alias"]:
+                if lo == alias.lower():
+                    lo = _n.lower()
+                    break
+
+    for _n in PLUGINS_PATH.iterdir():
+        if lo == _n.name.lower():
+            return _n.name
+    return None
+
+
+def resolve_sv(name: str):
+    """按名称查找 SV, 支持大小写不敏感, 返回 (name, sv)"""
+    sv = SL.lst.get(name)
+    if sv:
+        return name, sv
+    lo = name.lower()
+    for key, s in SL.lst.items():
+        if key.lower() == lo:
+            return key, s
+    return name, None
+
+
+def cfg_match(cfg: StringConfig, name: str) -> bool:
+    """判断配置是否属于指定插件/配置名"""
+    return cfg.plugin_name == name or (cfg.plugin_name is None and cfg.config_name == name)
+
+
+def find_config_item(plugin_name: str, key: str):
+    """查找配置项, 返回 (StringConfig, GSC) 或 None"""
+    for cfg in all_config_list.values():
+        if cfg_match(cfg, plugin_name) and key in cfg.config:
+            return cfg, cfg.config[key]
+    return None
+
+
+def plugin_configs(name: str) -> Dict[str, StringConfig]:
+    return {k: v for k, v in all_config_list.items() if cfg_match(v, name)}
+
+
+def all_config_names():
+    """返回所有可配置的名称集合"""
+    return {c.plugin_name for c in all_config_list.values() if c.plugin_name} | {
+        c.config_name for c in all_config_list.values() if c.plugin_name is None
+    }
+
+
+def match_config_name(text: str):
+    """从文本中最长前缀匹配已知配置名, 返回 (name, rest) 或 None"""
+    names = all_config_names()
+    best = None
+    for name in names:
+        if text == name or text.startswith(name + " "):
+            if best is None or len(name) > len(best):
+                best = name
+    if best is None:
+        return None
+    return best, text[len(best) :].strip()

--- a/gsuid_core/buildin_plugins/core_command/core_config_cmd/_setter.py
+++ b/gsuid_core/buildin_plugins/core_command/core_config_cmd/_setter.py
@@ -1,0 +1,227 @@
+from typing import Set, Optional
+
+from gsuid_core.utils.plugins_config.models import (
+    GSC,
+    GsIntConfig,
+    GsStrConfig,
+    GsBoolConfig,
+    GsListConfig,
+    GsTimeConfig,
+    GsTimeRConfig,
+    GsListStrConfig,
+)
+
+_BOOL_ON = {"开", "开启", "true", "on", "1", "是"}
+_BOOL_OFF = {"关", "关闭", "false", "off", "0", "否"}
+_CLEAR = {"空", "none", "clear", "清空"}
+_AREA_ALIAS = {"全部": "ALL", "群聊": "GROUP", "私聊": "DIRECT"}
+_LIST_HINT = "黑白名单用法: 直接输入=添加, -xxx=移除, =xxx=覆盖, 清空=清空"
+
+_INT_PARAMS = {
+    "优先级": "priority",
+    "priority": "priority",
+}
+
+PLUGIN_AREA = {"GROUP", "DIRECT", "ALL", "SV"}
+PLUGIN_PARAMS = f"开关, 权限, 优先级, 作用范围, 前缀, 别名, 黑名单, 白名单\n{_LIST_HINT}"
+PLUGIN_EXTRA = {"前缀": "prefix", "prefix": "prefix", "别名": "alias", "alias": "alias"}
+
+SV_AREA = {"GROUP", "DIRECT", "ALL"}
+SV_PARAMS = f"开关, 权限, 优先级, 作用范围, 黑名单, 白名单\n{_LIST_HINT}"
+
+
+def _split(raw: str):
+    return [x.strip() for x in raw.replace("，", ",").split(",") if x.strip()]
+
+
+def parse_val(item: GSC, raw: str):
+    """把用户输入解析成与配置项匹配的值, 失败返回 None"""
+    if isinstance(item, GsBoolConfig):
+        if raw.lower() in _BOOL_ON:
+            return True
+        if raw.lower() in _BOOL_OFF:
+            return False
+    elif isinstance(item, GsIntConfig):
+        try:
+            v = int(raw)
+            if item.options and v not in item.options:
+                return None
+            if item.max_value is not None and v > item.max_value:
+                return None
+            return v
+        except ValueError:
+            pass
+    elif isinstance(item, (GsStrConfig, GsTimeConfig)):
+        if isinstance(item, GsStrConfig) and item.options and raw not in item.options:
+            return None
+        return raw
+    elif isinstance(item, GsListStrConfig):
+        if raw.lower() in _CLEAR:
+            return []
+        vals = _split(raw)
+        if item.options and any(v not in item.options for v in vals):
+            return None
+        return vals
+    elif isinstance(item, GsListConfig):
+        try:
+            return [int(x) for x in _split(raw)]
+        except ValueError:
+            pass
+    elif isinstance(item, GsTimeRConfig):
+        try:
+            h, m = int(raw.split(":")[0]), int(raw.split(":")[1])
+            if 0 <= h <= 23 and 0 <= m <= 59:
+                return [h, m]
+        except (ValueError, IndexError):
+            pass
+    return None
+
+
+def _parse_hint(item: GSC) -> str:
+    """根据配置项类型生成输入格式提示"""
+    if isinstance(item, GsBoolConfig):
+        return "请输入: 开启 / 关闭"
+    if isinstance(item, GsIntConfig):
+        parts = ["请输入整数"]
+        if item.max_value is not None:
+            parts.append(f"最大 {item.max_value}")
+        if item.options:
+            parts.append(f"可选: {', '.join(str(o) for o in item.options)}")
+        return ", ".join(parts)
+    if isinstance(item, GsStrConfig):
+        if item.options:
+            return f"可选值: {', '.join(item.options)}"
+        return "请输入字符串"
+    if isinstance(item, GsListStrConfig):
+        hint = "请输入逗号分隔的字符串, 或输入 清空"
+        if item.options:
+            hint += f"\n可选值: {', '.join(item.options)}"
+        return hint
+    if isinstance(item, GsListConfig):
+        return "请输入逗号分隔的整数"
+    if isinstance(item, GsTimeRConfig):
+        return "请输入时间格式 HH:MM, 例如 01:05"
+    return "请检查输入格式"
+
+
+def _apply_list(target, label: str, name: str, field: str, raw_value: str) -> str:
+    current: list = getattr(target, field, [])
+    current_set = set(current)
+
+    if raw_value.lower() in _CLEAR:
+        target.set(is_lazy=False, **{field: []})
+        return f"{label} {name}: 已清空"
+
+    if raw_value.startswith("="):
+        vals = _split(raw_value[1:])
+        target.set(is_lazy=False, **{field: vals})
+        return f"{label} {name} 已设为: {', '.join(vals)}"
+
+    if raw_value.startswith("-"):
+        items = _split(raw_value[1:])
+        hit = [x for x in items if x in current_set]
+        miss = [x for x in items if x not in current_set]
+        target.set(is_lazy=False, **{field: [x for x in current if x not in set(items)]})
+        parts = []
+        if hit:
+            parts.append(f"已移除: {', '.join(hit)}")
+        if miss:
+            parts.append(f"不存在: {', '.join(miss)}")
+        return f"{label} {name} {'; '.join(parts)}"
+
+    items = _split(raw_value.lstrip("+"))
+    added = [x for x in items if x not in current_set]
+    duped = [x for x in items if x in current_set]
+    target.set(is_lazy=False, **{field: current + added})
+    parts = []
+    if added:
+        parts.append(f"已添加: {', '.join(added)}")
+    if duped:
+        parts.append(f"已存在: {', '.join(duped)}")
+    return f"{label} {name} {'; '.join(parts)}"
+
+
+def apply_set(
+    target,
+    label: str,
+    param: str,
+    raw_value: str,
+    area_values: Set[str],
+    all_params: str,
+    extra_params: Optional[dict] = None,
+) -> str:
+    """对插件/命令执行属性设置, 返回结果消息"""
+    if param in ("开关", "enabled"):
+        v = raw_value.lower()
+        if v in _BOOL_ON:
+            target.set(is_lazy=False, enabled=True)
+            return f"{label} 已开启"
+        if v in _BOOL_OFF:
+            target.set(is_lazy=False, enabled=False)
+            return f"{label} 已关闭"
+        return "开关值请输入: 开启 / 关闭"
+
+    if param in ("权限", "pm"):
+        try:
+            v = int(raw_value)
+        except ValueError:
+            return "权限必须是整数 (0=master, 1=superuser, 2=管理员, 6=普通用户)"
+        if not 0 <= v <= 6:
+            return "权限范围: 0-6 (0=master, 1=superuser, 2=管理员, 6=普通用户)"
+        target.set(is_lazy=False, pm=v)
+        return f"{label} 权限已设置为 {v}"
+
+    if param in _INT_PARAMS:
+        field = _INT_PARAMS[param]
+        try:
+            target.set(is_lazy=False, **{field: int(raw_value)})
+            return f"{label} {param}已设置为 {raw_value}"
+        except ValueError:
+            return f"{param}必须是整数"
+
+    if param in ("作用范围", "area"):
+        val = _AREA_ALIAS.get(raw_value, raw_value.upper())
+        if val not in area_values:
+            return f"作用范围可选: {', '.join(sorted(area_values))} (全部/群聊/私聊)"
+        target.set(is_lazy=False, area=val)
+        return f"{label} 作用范围已设置为 {val}"
+
+    if param in ("黑名单", "black_list"):
+        return _apply_list(target, label, "黑名单", "black_list", raw_value)
+
+    if param in ("白名单", "white_list"):
+        return _apply_list(target, label, "白名单", "white_list", raw_value)
+
+    if extra_params and param in extra_params:
+        field = extra_params[param]
+        vals = [] if raw_value.lower() in _CLEAR else _split(raw_value)
+        target.set(is_lazy=False, **{field: vals})
+        result = f"{label} {param}: {'已清空' if not vals else ', '.join(vals)}"
+        if field == "prefix":
+            result += "\n(前缀修改需重启后生效)"
+        return result
+
+    return f"未知参数: {param}\n可用: {all_params}"
+
+
+def set_config_val(
+    cfg,
+    plugin_name: str,
+    key: str,
+    raw_value: str,
+    is_skip,
+    fmt,
+) -> str:
+    """设置配置项, is_skip/fmt 由调用方注入, 避免依赖渲染层"""
+    item = cfg.config[key]
+
+    if is_skip(item):
+        return "该类型配置请使用 WebConsole 修改"
+
+    value = parse_val(item, raw_value)
+    if value is None:
+        return f"值解析失败: {key}\n  输入: {raw_value}\n  {_parse_hint(item)}"
+
+    if cfg.set_config(key, value):
+        return f"[{plugin_name}] {key} 已设置为: {fmt(cfg.config[key], key)}"
+    return "设置失败, 类型不匹配"

--- a/gsuid_core/buildin_plugins/core_command/core_config_cmd/_setter.py
+++ b/gsuid_core/buildin_plugins/core_command/core_config_cmd/_setter.py
@@ -52,6 +52,8 @@ def parse_val(item: GSC, raw: str):
         except ValueError:
             pass
     elif isinstance(item, (GsStrConfig, GsTimeConfig)):
+        if raw.lower() in _CLEAR:
+            return ""
         if isinstance(item, GsStrConfig) and item.options and raw not in item.options:
             return None
         return raw
@@ -63,6 +65,8 @@ def parse_val(item: GSC, raw: str):
             return None
         return vals
     elif isinstance(item, GsListConfig):
+        if raw.lower() in _CLEAR:
+            return []
         try:
             return [int(x) for x in _split(raw)]
         except ValueError:


### PR DESCRIPTION
## Summary
- 新增 `core_config_cmd` 模块, 支持通过聊天命令管理配置、插件和命令(SV)
- 查看配置/设置配置: 支持带空格的配置名匹配、插件别名解析、敏感字段脱敏
- 查看插件/设置插件: 支持开关、权限(0-6)、优先级、作用范围、前缀、别名、黑白名单
- 查看命令/设置命令: 支持按插件名过滤命令列表
- 黑白名单支持增量操作: 直接输入=添加, -xxx=移除, =xxx=覆盖, 清空
- Dict/Image 类型配置拦截, 引导使用 WebConsole
- 每级查看结果带下一步操作提示
- 值校验: 权限0-6、时间HH:MM范围、options可选值限制
- 设置立即持久化(is_lazy=False), 前缀修改提示需重启

## 模块结构
```
core_config_cmd/
├── __init__.py    命令处理器(协调层)
├── _resolve.py    名称解析(插件/命令/配置名匹配)
├── _render.py     输出渲染(后续可替换为Pillow图片)
└── _setter.py     设置逻辑(值解析/属性设置/黑白名单)
```

## Test plan
- [ ] 查看配置 / 查看配置 <插件名> / 查看配置 <插件名> <键>
- [ ] 设置配置 各类型值校验(Bool/Int/Str/List/Time)
- [ ] 插件别名解析(如 dna → DNAUID)
- [ ] 带空格的配置名匹配(如 GsCore AI OpenAI配置)
- [ ] 黑白名单增量操作(添加/移除/覆盖/清空)
- [ ] 敏感字段脱敏(token/key/password等)
- [ ] Dict/Image类型拦截
- [ ] 查看命令按插件名过滤