### PR TITLE
🐛修复扫码登录

### DIFF
--- a/gsuid_core/utils/api/mys/api.py
+++ b/gsuid_core/utils/api/mys/api.py
@@ -44,7 +44,7 @@ GET_STOKEN_URL = f"{GS_BASE}/auth/api/getMultiTokenByLoginTicket"
 # 国际服
 GET_STOKEN_URL_OS = f"{ACCOUNT_URL_OS}/account/auth/api/getMultiTokenByLoginTicket"
 # 通过Stoken获取Cookie_token
-GET_COOKIE_TOKEN_URL = f"{GS_BASE}/auth/api/getCookieAccountInfoBySToken"
+GET_COOKIE_TOKEN_URL = f"{PASSPORT_URL}/account/auth/api/getCookieAccountInfoBySToken"
 # 通过Stoken获取AuthKey
 GET_AUTHKEY_URL = f"{GS_BASE}/binding/api/genAuthKey"
 # 通过AuthKey获取gachalogs

--- a/gsuid_core/utils/cookie_manager/qrlogin.py
+++ b/gsuid_core/utils/cookie_manager/qrlogin.py
@@ -114,16 +114,14 @@ async def qrcode_login(bot: Bot, ev: Event, user_id: str) -> str:
         )
         if isinstance(stoken_data, int):
             return await send_msg("[登录]获取SK失败...")
+
         account_id = game_token_data["uid"]
         stoken = stoken_data["token"]["token"]
         mid = stoken_data["user_info"]["mid"]
         app_cookie = f"stuid={account_id};stoken={stoken};mid={mid}"
+
         ck = await mys_api.get_cookie_token_by_stoken(stoken, account_id, app_cookie)
         if isinstance(ck, int):
-            return await send_msg("[登录]获取CK失败...")
-        cookie_token = ck["cookie_token"]
-
-        if isinstance(cookie_token, int):
             return await send_msg("[登录]获取CK失败...")
 
         return SimpleCookie(
@@ -131,7 +129,7 @@ async def qrcode_login(bot: Bot, ev: Event, user_id: str) -> str:
                 "stoken_v2": stoken_data["token"]["token"],
                 "stuid": stoken_data["user_info"]["aid"],
                 "mid": stoken_data["user_info"]["mid"],
-                "cookie_token": cookie_token,
+                "cookie_token": ck["cookie_token"],
             }
         ).output(header="", sep=";")
     else:

--- a/gsuid_core/utils/cookie_manager/qrlogin.py
+++ b/gsuid_core/utils/cookie_manager/qrlogin.py
@@ -108,7 +108,6 @@ async def qrcode_login(bot: Bot, ev: Event, user_id: str) -> str:
     if status:
         assert game_token_data is not None  # 骗过 pyright
         logger.info("[登录]game_token获取成功")
-        cookie_token = await mys_api.get_cookie_token(**game_token_data)
         stoken_data = await mys_api.get_stoken_by_game_token(
             account_id=int(game_token_data["uid"]),
             game_token=game_token_data["token"],
@@ -122,7 +121,7 @@ async def qrcode_login(bot: Bot, ev: Event, user_id: str) -> str:
         ck = await mys_api.get_cookie_token_by_stoken(stoken, account_id, app_cookie)
         if isinstance(ck, int):
             return await send_msg("[登录]获取CK失败...")
-        ck = ck["cookie_token"]
+        cookie_token = ck["cookie_token"]
 
         if isinstance(cookie_token, int):
             return await send_msg("[登录]获取CK失败...")
@@ -132,7 +131,7 @@ async def qrcode_login(bot: Bot, ev: Event, user_id: str) -> str:
                 "stoken_v2": stoken_data["token"]["token"],
                 "stuid": stoken_data["user_info"]["aid"],
                 "mid": stoken_data["user_info"]["mid"],
-                "cookie_token": cookie_token["cookie_token"],
+                "cookie_token": cookie_token,
             }
         ).output(header="", sep=";")
     else:


### PR DESCRIPTION
原接口貌似是被弃用了，报错信息：
```
2026-04-17 23:58:23 [info     ] [登录]二维码已确认       
2026-04-17 23:58:23 [info     ] [登录]game_token获取成功
2026-04-17 23:58:23 [debug    ] [米游社请求] BaseUrl: None
2026-04-17 23:58:23 [debug    ] [米游社请求] Url: https://api-takumi.mihoyo.com/auth/api/getCookieAccountInfoByGameToken
2026-04-17 23:58:23 [debug    ] [米游社请求] Params: {'game_token': '***', 'account_id': '***'}
2026-04-17 23:58:23 [debug    ] [米游社请求] Data: None
2026-04-17 23:58:23 [debug    ] {'x-rpc-app_version': '2.102.1', 'X-Requested-With': 'com.mihoyo.hyperion', 'User-Agent': 'Mozilla/5.0 (Linux; Android 13; PHK110 Build/SKQ1.221119.001; wv)AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/126.0.6478.133 Mobile Safari/537.36 miHoYoBBS/2.102.1', 'x-rpc-client_type': '5', 'Referer': 'https://webstatic.mihoyo.com/', 'Origin': 'https://webstatic.mihoyo.com/'}
2026-04-17 23:58:23 [debug    ] {'data': None, 'message': '请使用最新版本产品/链接以获得更佳体验，或前往user.mihoyo.com完成操作。', 'retcode': -5300}
```
替换为了`https://passport-api.mihoyo.com/account/auth/api/getCookieAccountInfoBySToken`