### PR TITLE
🐛 修正插件 __init__.py 在单次启动中被 exec 多次

### DIFF
--- a/gsuid_core/server.py
+++ b/gsuid_core/server.py
@@ -247,7 +247,7 @@ class GsServer:
 
             module_list.append(
                 (
-                    f"{plugin_parent}.{name1}.{name2}.__init__",
+                    f"{plugin_parent}.{name1}.{name2}",
                     init_path,
                     "plugin",
                 )
@@ -325,7 +325,7 @@ class GsServer:
                 elif plugin_path.exists():
                     module_list = [
                         (
-                            f"{plugin_parent}.{plugin.name}.__init__",
+                            f"{plugin_parent}.{plugin.name}",
                             plugin_path,
                             "plugin",
                         )


### PR DESCRIPTION
关联 issue: #219

## 问题

插件顶层 `__init__.py` 的模块级代码在单次启动里被执行多次。装饰器注册的 handler 重复注册，模块级单例被实例化多份，初始化日志多次输出。

实测一次启动（XutheringWavesUID）：
- 模块级初始化函数 → 4 次
- 装饰器 `event_handler` 注册 → 3 轮（每轮 4 个 handler，日志 12 行）
- 另一插件 RoverReminder 初始化日志 → 2 次

## 根因

`server.py:250 / :328` 给插件 `__init__.py` 注入的 module name 带 `.__init__` 后缀：

```python
f"{plugin_parent}.{name1}.{name2}.__init__"
```

CPython `importlib._bootstrap_external` 仅当 `tail_name != "__init__"` 时把文件标记为 package。带 `.__init__` 后缀的 name 不会被识别为 package：spec 的 `submodule_search_locations` 为 `None`，`ModuleSpec.parent`（对非 package spec 由 name 去掉最后一段派生）解析为 `{plugin_parent}.{name1}.{name2}`。

`__init__.py` exec 时遇到相对 import，Python 拿这个 parent 去 `sys.modules` 查父 package —— 找不到（只有带 `.__init__` 后缀的版本）。`_find_and_load_unlocked` 退回 finder 链。`server.py:246/263/302` 把 `plugins/`、`plugins/X/`、`plugins/X/X/` 都 append 到 `sys.path` —— 多条 sys.path 入口让 finder 能以另一个 module key 解析到同一份 `__init__.py`，文件被重新加载。

## 修复

去掉 `.__init__` 后缀。一旦 module name 是 `a.b.c`，`spec_from_file_location` 自动检测 `__init__.py` 文件并填好 `submodule_search_locations`，spec 被标记为 package，子模块的相对 import 从已注入的父包解析，不再走 finder 重载。

## 影响范围

- 单文件 `.py` 插件分支（line 334-336）原本就没带后缀，不受影响。
- `_module_cache` 仅在 `cached_import` 内部使用，无外部消费者依赖旧 key。
- 仓内无任何处通过字面量 `".__init__"` 字符串访问 sys.modules / `__import__`。
- `reload_plugin()` 已被禁用，不在本次影响面。

## 验证方法

启动一次，对比之前的日志，确认装饰器注册、模块级单例、插件初始化日志的次数从 N 降到 1。 