### PR TITLE
⚡ 新增 buffered_user_writes 配置, 减少 CoreUser/Group 同步写入开销

### DIFF
--- a/gsuid_core/config.py
+++ b/gsuid_core/config.py
@@ -36,6 +36,7 @@ CONFIG_DEFAULT = {
     },
     "enable_empty_start": True,
     "command_start": [],
+    "buffered_user_writes": False,
     "sv": {},
 }
 
@@ -43,7 +44,7 @@ STR_CONFIG = Literal["HOST", "PORT", "WS_TOKEN", "REGISTER_CODE"]
 INT_CONFIG = Literal["misfire_grace_time"]
 LIST_CONFIG = Literal["superusers", "masters", "command_start", "TRUSTED_IPS"]
 DICT_CONFIG = Literal["sv", "log"]
-BOOL_CONFIG = Literal["enable_empty_start", "ENABLE_HTTP"]
+BOOL_CONFIG = Literal["enable_empty_start", "ENABLE_HTTP", "buffered_user_writes"]
 
 plugins_sample = {
     "name": "",

--- a/gsuid_core/handler.py
+++ b/gsuid_core/handler.py
@@ -1,15 +1,15 @@
 import asyncio
 from copy import deepcopy
 from uuid import uuid4
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Tuple, Optional
 
 from gsuid_core.sv import SL
 from gsuid_core.bot import Bot, _Bot
 from gsuid_core.config import core_config
 from gsuid_core.logger import logger
 from gsuid_core.models import Event, Message, TaskContext, MessageReceive
-from gsuid_core.trigger import Trigger
 from gsuid_core.server import on_core_shutdown
+from gsuid_core.trigger import Trigger
 from gsuid_core.subscribe import gs_subscribe
 from gsuid_core.global_val import get_platform_val
 from gsuid_core.ai_core.memory import observe
@@ -72,7 +72,7 @@ async def _flush_user_group_buffer():
             await CoreUser.insert_user(rbi, uid, gid, nick, avatar)
         except Exception as e:
             logger.warning(f"[GsCore] 缓冲 CoreUser 写入失败: {e}")
-    for (rbi, gid) in g_pending:
+    for rbi, gid in g_pending:
         try:
             await CoreGroup.insert_group(rbi, gid)
         except Exception as e:

--- a/gsuid_core/handler.py
+++ b/gsuid_core/handler.py
@@ -1,7 +1,7 @@
 import asyncio
 from copy import deepcopy
 from uuid import uuid4
-from typing import Dict, List
+from typing import Dict, List, Optional, Tuple
 
 from gsuid_core.sv import SL
 from gsuid_core.bot import Bot, _Bot
@@ -9,6 +9,7 @@ from gsuid_core.config import core_config
 from gsuid_core.logger import logger
 from gsuid_core.models import Event, Message, TaskContext, MessageReceive
 from gsuid_core.trigger import Trigger
+from gsuid_core.server import on_core_shutdown
 from gsuid_core.subscribe import gs_subscribe
 from gsuid_core.global_val import get_platform_val
 from gsuid_core.ai_core.memory import observe
@@ -44,6 +45,80 @@ IS_HANDDLE: bool = True
 def set_handle(is_handle: bool):
     global IS_HANDDLE
     IS_HANDDLE = is_handle
+
+
+# ===== CoreUser / CoreGroup 缓冲写入（参考 XutheringWavesUID 活跃度模式）=====
+# 默认关闭, 走原同步 await 路径; 启用后 60s 批量 flush, 退出时强制 flush.
+_BUFFERED_USER_WRITES: bool = bool(core_config.get_config("buffered_user_writes"))
+_USER_FLUSH_INTERVAL: float = 60.0
+
+_user_buffer: Dict[Tuple[str, str], Tuple[Optional[str], Optional[str], Optional[str]]] = {}
+_group_buffer: set = set()
+_user_flush_shutdown_event: asyncio.Event = asyncio.Event()
+_user_flush_task: Optional[asyncio.Task] = None
+
+
+async def _flush_user_group_buffer():
+    """把缓冲区中的 CoreUser/CoreGroup 写入批量刷到数据库."""
+    if not _user_buffer and not _group_buffer:
+        return
+    u_pending = dict(_user_buffer)
+    _user_buffer.clear()
+    g_pending = set(_group_buffer)
+    _group_buffer.clear()
+
+    for (rbi, uid), (gid, nick, avatar) in u_pending.items():
+        try:
+            await CoreUser.insert_user(rbi, uid, gid, nick, avatar)
+        except Exception as e:
+            logger.warning(f"[GsCore] 缓冲 CoreUser 写入失败: {e}")
+    for (rbi, gid) in g_pending:
+        try:
+            await CoreGroup.insert_group(rbi, gid)
+        except Exception as e:
+            logger.warning(f"[GsCore] 缓冲 CoreGroup 写入失败: {e}")
+
+
+async def _user_flush_loop():
+    """后台循环 60s 一次刷写, shutdown event 触发立即退出."""
+    while not _user_flush_shutdown_event.is_set():
+        try:
+            await asyncio.wait_for(_user_flush_shutdown_event.wait(), timeout=_USER_FLUSH_INTERVAL)
+            break
+        except asyncio.TimeoutError:
+            pass
+        try:
+            await _flush_user_group_buffer()
+        except Exception as e:
+            logger.warning(f"[GsCore] CoreUser/Group 缓冲刷写循环异常: {e}")
+
+
+def _ensure_flush_task_started():
+    """首次缓冲写入时懒启动后台 flush 任务."""
+    global _user_flush_task
+    if _user_flush_task is None or _user_flush_task.done():
+        try:
+            _user_flush_task = asyncio.get_event_loop().create_task(_user_flush_loop())
+        except RuntimeError:
+            _user_flush_task = None
+
+
+@on_core_shutdown
+async def _flush_user_buffer_on_shutdown():
+    """退出前最后一次刷写, 防止丢数据."""
+    if not _BUFFERED_USER_WRITES:
+        return
+    logger.info("[GsCore] 退出前停止 CoreUser/Group 缓冲刷写循环...")
+    _user_flush_shutdown_event.set()
+    global _user_flush_task
+    if _user_flush_task is not None:
+        try:
+            await asyncio.wait_for(_user_flush_task, timeout=30)
+        except asyncio.TimeoutError:
+            _user_flush_task.cancel()
+    logger.info("[GsCore] 刷写 CoreUser/Group 缓冲区...")
+    await _flush_user_group_buffer()
+    logger.info("[GsCore] CoreUser/Group 缓冲区刷写完成")
 
 
 async def handle_event(ws: _Bot, msg: MessageReceive, is_http: bool = False):
@@ -167,18 +242,31 @@ async def handle_event(ws: _Bot, msg: MessageReceive, is_http: bool = False):
     if event.sender and "avatar" in event.sender:
         sender_avater = event.sender["avatar"]
 
-    await CoreUser.insert_user(
-        event.real_bot_id,
-        event.user_id,
-        event.group_id,
-        sender_nickname,
-        sender_avater,
-    )
-    if event.group_id:
-        await CoreGroup.insert_group(
+    if _BUFFERED_USER_WRITES:
+        _key_u = (event.real_bot_id, event.user_id)
+        if _key_u in _user_buffer:
+            _old_gid, _old_nick, _old_avatar = _user_buffer[_key_u]
+            if not sender_nickname:
+                sender_nickname = _old_nick
+            if not sender_avater:
+                sender_avater = _old_avatar
+        _user_buffer[_key_u] = (event.group_id, sender_nickname, sender_avater)
+        if event.group_id:
+            _group_buffer.add((event.real_bot_id, event.group_id))
+        _ensure_flush_task_started()
+    else:
+        await CoreUser.insert_user(
             event.real_bot_id,
+            event.user_id,
             event.group_id,
+            sender_nickname,
+            sender_avater,
         )
+        if event.group_id:
+            await CoreGroup.insert_group(
+                event.real_bot_id,
+                event.group_id,
+            )
 
     bid = event.bot_id if event.bot_id else "0"
     uid = event.user_id if event.user_id else "0"


### PR DESCRIPTION
## 问题

`handle_event` 每条消息都同步 `await CoreUser.insert_user(...)` + `await CoreGroup.insert_group(...)`，但 99% 的 upsert 数据（nickname/avatar）与上次完全相同，纯重复劳动。生产实测：每事件平均 **13.84ms**，max **2044ms**（SQLite WAL 锁竞争 / checkpoint），占 handle_event **99%** 时间、约 **8% 单核 CPU**。

## 改动

参考同仓库 `XutheringWavesUID` 活跃度批量写入模式（`__init__.py:27-84`），加 `buffered_user_writes` 配置项：

- **默认 `False`** — 走原 `await` 路径，**与现有行为完全等价，不破坏任何用户**
- **设为 `True`** — 60s 批量 flush 到数据库
  - 内存 dict 缓冲，同 user/group 自动去重
  - 空 nickname/avatar 不覆盖已缓存非空（避免占位值覆盖真值）
  - 后台 flush 任务用 `wait_for(shutdown_event, timeout=60)` 模式，shutdown 时立即响应
  - `@on_core_shutdown` 强制最后一次 flush，防止丢数据

仅改 2 个文件：`config.py`（加 option）、`handler.py`（缓冲基础设施 + 条件分支）。

## 生产实测

QQ Bot 生产环境，启用 `buffered_user_writes=true` 后跑 5 分钟、4753 events：

| 指标 | 改前 | 改后 | 比例 |
|---|---|---|---|
| `CoreUser.insert + CoreGroup.insert` avg/event | 13.84 ms | **0.003 ms** | **-4600x** |
| 单次最大耗时 | 2044 ms | **0.03 ms** | -68000x |
| ww-core 单核 CPU（instant） | ~32% | **~5%** | -27 pp |

handle_event 这一段从原本占 99% 时间直接消失为噪声。

## 兼容性

- **默认不变** — `False` 时控制流和写入语义与现有代码完全相同
- **启用后** nickname/avatar 数据库更新延迟最多 60s，shutdown 时强制 flush 不丢数据
- 唯一 corner case：新用户加群后立即被 @ 查询 nickname（如 `ZZZeroUID/utils/image.py:199`）可能查不到，但该场景极少

## 设计参考

完全照搬 `XutheringWavesUID` 活跃度模式，已在生产长期运行验证：
- `gsuid_core/plugins/XutheringWavesUID/XutheringWavesUID/__init__.py:27-84`
- 同样的 dict + 60s + on_core_shutdown 三件套

<details>
<summary>📊 启用前后日志对比</summary>

启用前（旧实现）：

\`\`\`
[GSCORE_PERF] ===== 性能报告 @ 2026-05-12T23:49:03 =====
--- handle_event_stages ---
  db_user_group       total=23381.4ms  cnt=1690  avg=13.835ms  max=2044.40ms
  post_dispatch       total=   49.1ms  cnt= 100  avg= 0.491ms  max=   2.68ms
  history_add         total=   34.8ms  cnt=1290  avg= 0.027ms  max=   0.06ms
  msg_process         total=   24.8ms  cnt=1690  avg= 0.015ms  max=   0.11ms
\`\`\`

启用后（新实现）：

\`\`\`
[GSCORE_PERF] ===== 性能报告 @ 2026-05-13T00:18:43 =====
--- handle_event_stages ---
  history_add         total= 1669.8ms  cnt=3636  avg=0.459ms  max=577.55ms
  post_dispatch       total=  287.4ms  cnt= 329  avg=0.874ms  max= 20.65ms
  msg_process         total=   68.6ms  cnt=4753  avg=0.014ms
  db_user_group       total=   14.3ms  cnt=4753  avg=0.003ms  max=  0.03ms   ← 从最大头变为噪声
\`\`\`

（注：上方报告由本地诊断埋点产出，不在本 PR 范围内。）

</details>

<details>
<summary>🔍 设计决策说明</summary>

- **option 而非默认开启**：60s 延迟有 corner case 影响，谨慎默认；用户主动开启表示接受 tradeoff
- **lazy start flush task**：只在第一次缓冲写入时启动后台任务，关闭路径下完全惰性
- **shutdown timeout 30s**：给 in-flight flush 充足完成时间；超时则 cancel + 最后再 flush 一次
- **保留 try/except + logger.warning**：参考 xwuid 实现，单条失败不影响其他

</details>