### PR TITLE
🐛 修复 on_message 被动 hook 阻塞 AI fallback 分支

### DIFF
--- a/gsuid_core/handler.py
+++ b/gsuid_core/handler.py
@@ -277,7 +277,22 @@ async def handle_event(ws: _Bot, msg: MessageReceive, is_http: bool = False):
                             f"[GsCore] trigger.check_command 异常: type={_trigger.type} keyword={_trigger.keyword!r}"
                         )
 
-    if len(valid_event) >= 1:
+    command_triggers = {t: p for t, p in valid_event.items() if t.type != "message"}
+    message_triggers = {t: p for t, p in valid_event.items() if t.type == "message"}
+
+    for trigger in message_triggers:
+        _event = deepcopy(event)
+        message = await trigger.get_command(_event)
+        _event.task_id = str(uuid4())
+        bot = Bot(ws, _event)
+        await count_data(event, trigger)
+        logger.trace("[命令触发] [on_message]", command=message)
+        coro = trigger.func(bot, message)
+        func_name = getattr(coro, "__qualname__", str(coro))
+        task_ctx = TaskContext(coro=coro, name=func_name, priority=_event.user_pm)
+        ws.queue.put_nowait(task_ctx)
+
+    if len(command_triggers) >= 1:
         if event.at:
             for shield_id in shield_list:
                 if event.at.startswith(shield_id):
@@ -285,7 +300,7 @@ async def handle_event(ws: _Bot, msg: MessageReceive, is_http: bool = False):
                     return
 
         sorted_event = sorted(
-            valid_event.items(),
+            command_triggers.items(),
             key=lambda x: (not x[0].prefix, x[1]),
         )
 
@@ -301,14 +316,11 @@ async def handle_event(ws: _Bot, msg: MessageReceive, is_http: bool = False):
 
             await count_data(event, trigger)
 
-            if trigger.type != "message":
-                logger.info(
-                    "[命令触发]",
-                    trigger=[_event.raw_text, trigger.type, trigger.keyword],
-                )
-                logger.info("[命令触发]", command=message)
-            else:
-                logger.trace("[命令触发] [on_message]", command=message)
+            logger.info(
+                "[命令触发]",
+                trigger=[_event.raw_text, trigger.type, trigger.keyword],
+            )
+            logger.info("[命令触发]", command=message)
 
             coro = trigger.func(bot, message)
             func_name = getattr(coro, "__qualname__", str(coro))


### PR DESCRIPTION
## Summary

`handle_event` 里 `len(valid_event) >= 1` 这个判定没有区分 trigger 类型。一旦
环境中挂着任意 `on_message(block=False)` 这类被动 hook（典型场景：AT 追踪
类插件），`valid_event` 在每条消息上都不为空，handler 永远进入 SV 分支并跳过
`else` 里的 AI persona 提及应答逻辑——结果就是：只要被动 hook 存在，AI 就再
也不会响应非命令消息。

修复：先按 `trigger.type` 把 `valid_event` 拆成 `command_triggers` 和
`message_triggers`。被动 `message_triggers` 始终 dispatch 进 task queue，但
不再纳入"是否进入 AI fallback"的判定；只有命令类 trigger 才会让分支走 SV。

## Test plan

- [x] 本地复现：用户私聊 `d小维你好`（无任何命令 SV 匹配），未修前 core 收到
  事件但 AI 无任何响应；启用 trace 日志可见 `valid_event count=1, type='message'`。
- [x] 应用修复后，同一条消息进入 AI 分支，命中 persona 关键词/`is_tome`，正常
  生成回复。
- [x] 已有命令（如 `xwmr` 等 fullmatch / prefix / regex / keyword 触发）仍按原
  逻辑走 SV 分支，未受影响。
- [x] `on_message` hook 仍会 dispatch（如 AT 追踪），未丢失被动观察能力。