### PR TITLE
✨feat: 新增 recall 和 wait_send_result 消息参数

### DIFF
--- a/gsuid_core/ai_core/trigger_bridge.py
+++ b/gsuid_core/ai_core/trigger_bridge.py
@@ -90,6 +90,7 @@ class MockBot:
         self,
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
+        recall: int = 0,
     ) -> None:
         """拦截 send：文本存入上下文返回给 AI，图片通过 RM 注册并返回资源 ID。"""
         ctx = object.__getattribute__(self, "_ctx")
@@ -118,9 +119,10 @@ class MockBot:
         self,
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
+        recall: int = 0,
     ) -> None:
         """拦截 reply，行为与 send 相同。"""
-        await self.send(message, at_sender)
+        await self.send(message, at_sender, recall)
 
     async def send_option(
         self,

--- a/gsuid_core/ai_core/trigger_bridge.py
+++ b/gsuid_core/ai_core/trigger_bridge.py
@@ -91,6 +91,7 @@ class MockBot:
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
         recall: int = 0,
+        active_message: bool = False,
     ) -> None:
         """拦截 send：文本存入上下文返回给 AI，图片通过 RM 注册并返回资源 ID。"""
         ctx = object.__getattribute__(self, "_ctx")
@@ -120,9 +121,10 @@ class MockBot:
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
         recall: int = 0,
+        active_message: bool = False,
     ) -> None:
         """拦截 reply，行为与 send 相同。"""
-        await self.send(message, at_sender, recall)
+        await self.send(message, at_sender, recall, active_message)
 
     async def send_option(
         self,

--- a/gsuid_core/ai_core/trigger_bridge.py
+++ b/gsuid_core/ai_core/trigger_bridge.py
@@ -91,7 +91,7 @@ class MockBot:
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
         recall: int = 0,
-        active_message: bool = False,
+        wait_send_result: bool = False,
     ) -> None:
         """拦截 send：文本存入上下文返回给 AI，图片通过 RM 注册并返回资源 ID。"""
         ctx = object.__getattribute__(self, "_ctx")
@@ -121,10 +121,10 @@ class MockBot:
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
         recall: int = 0,
-        active_message: bool = False,
+        wait_send_result: bool = False,
     ) -> None:
         """拦截 reply，行为与 send 相同。"""
-        await self.send(message, at_sender, recall, active_message)
+        await self.send(message, at_sender, recall, wait_send_result)
 
     async def send_option(
         self,

--- a/gsuid_core/bot.py
+++ b/gsuid_core/bot.py
@@ -5,8 +5,7 @@ from uuid import uuid4
 from typing import Any, Dict, List, Union, Literal, Optional
 
 from fastapi import WebSocket
-from msgspec import to_builtins
-from msgspec import json as msgjson
+from msgspec import json as msgjson, to_builtins
 from starlette.websockets import WebSocketState
 
 from gsuid_core.logger import logger

--- a/gsuid_core/bot.py
+++ b/gsuid_core/bot.py
@@ -108,7 +108,7 @@ class _Bot:
         self.logger = GsLogger(self.bot_id, ws)
         self.queue = asyncio.queues.PriorityQueue()
         self.send_dict = {}
-        self.active_message_results: Dict[str, asyncio.Future] = {}
+        self.send_result_waiters: Dict[str, asyncio.Future] = {}
         self.bg_tasks: set[asyncio.Task] = set()
         self.sem = asyncio.Semaphore(10)
         self._shutdown_event: Optional[asyncio.Event] = None
@@ -205,8 +205,7 @@ class _Bot:
         task_id: str = "",
         task_event: Optional[asyncio.Event] = None,
         recall: int = 0,
-        active_message: bool = False,
-        wait_active_result: bool = False,
+        wait_send_result: bool = False,
     ):
         # 记录 bot 回复到历史记录
         try:
@@ -352,11 +351,11 @@ class _Bot:
             recall = 120
 
         send_id = ""
-        active_result_future = None
-        if active_message and wait_active_result:
+        send_result_future = None
+        if wait_send_result:
             send_id = uuid4().hex
-            active_result_future = asyncio.get_running_loop().create_future()
-            self.active_message_results[send_id] = active_result_future
+            send_result_future = asyncio.get_running_loop().create_future()
+            self.send_result_waiters[send_id] = send_result_future
 
         for mr in message_result:
             logger.trace("[GsCore][即将发送消息]", messages=_truncate_for_log(mr))
@@ -378,7 +377,7 @@ class _Bot:
                 target_id=target_id,
                 msg_id=msg_id,
                 recall=recall,
-                active_message=active_message,
+                wait_send_result=wait_send_result,
             )
 
             local_val = await get_global_val(bot_id, bot_self_id)
@@ -431,16 +430,16 @@ class _Bot:
                 # WS 模式：无论连没连都入队，worker 会等重连
                 await self._enqueue_send(_do_send())
 
-        if active_result_future is not None:
+        if send_result_future is not None:
             try:
-                return await asyncio.wait_for(active_result_future, timeout=15)
+                return await asyncio.wait_for(send_result_future, timeout=15)
             except asyncio.TimeoutError:
                 return None
             finally:
-                self.active_message_results.pop(send_id, None)
+                self.send_result_waiters.pop(send_id, None)
 
-    def set_active_message_result(self, send_id: str, success: bool) -> None:
-        future = self.active_message_results.get(send_id)
+    def set_send_result(self, send_id: str, success: bool) -> None:
+        future = self.send_result_waiters.get(send_id)
         if future is not None and not future.done():
             future.set_result(success)
 
@@ -588,15 +587,13 @@ class Bot:
         sep: str = "\n",
         command_tips: str = "请输入以下命令之一:",
         command_start_text: str = "",
-        active_message: bool = False,
-        wait_active_result: bool = False,
+        wait_send_result: bool = False,
     ):
         if option_list is None:
             if reply:
                 return await self.send(
                     reply,
-                    active_message=active_message,
-                    wait_active_result=wait_active_result,
+                    wait_send_result=wait_send_result,
                 )
             return None
 
@@ -757,8 +754,7 @@ class Bot:
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
         recall: int = 0,
-        active_message: bool = False,
-        wait_active_result: bool = False,
+        wait_send_result: bool = False,
     ):
         return await self.bot.target_send(
             message,
@@ -773,8 +769,7 @@ class Bot:
             self.ev.task_id,
             self.ev.task_event,
             recall=recall,
-            active_message=active_message,
-            wait_active_result=wait_active_result,
+            wait_send_result=wait_send_result,
         )
 
     async def target_send(
@@ -786,8 +781,7 @@ class Bot:
         sender_id: str = "",
         send_source_group: Optional[str] = None,
         recall: int = 0,
-        active_message: bool = False,
-        wait_active_result: bool = False,
+        wait_send_result: bool = False,
     ):
         return await self.bot.target_send(
             message,
@@ -800,8 +794,7 @@ class Bot:
             sender_id,
             send_source_group,
             recall=recall,
-            active_message=active_message,
-            wait_active_result=wait_active_result,
+            wait_send_result=wait_send_result,
         )
 
 

--- a/gsuid_core/bot.py
+++ b/gsuid_core/bot.py
@@ -201,6 +201,7 @@ class _Bot:
         group_id: Optional[str] = None,
         task_id: str = "",
         task_event: Optional[asyncio.Event] = None,
+        recall: int = 0,
     ):
         # 记录 bot 回复到历史记录
         try:
@@ -340,6 +341,11 @@ class _Bot:
             if _temp_mr:
                 message_result.append(_temp_mr)
 
+        if recall < 0:
+            recall = 0
+        elif recall > 120:
+            recall = 120
+
         for mr in message_result:
             logger.trace("[GsCore][即将发送消息]", messages=_truncate_for_log(mr))
             if at_sender and sender_id:
@@ -358,6 +364,7 @@ class _Bot:
                 target_type=target_type,
                 target_id=target_id,
                 msg_id=msg_id,
+                recall=recall,
             )
 
             local_val = await get_global_val(bot_id, bot_self_id)
@@ -708,6 +715,7 @@ class Bot:
         self,
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
+        recall: int = 0,
     ):
         return await self.bot.target_send(
             message,
@@ -721,6 +729,7 @@ class Bot:
             self.ev.group_id,
             self.ev.task_id,
             self.ev.task_event,
+            recall=recall,
         )
 
     async def target_send(
@@ -731,6 +740,7 @@ class Bot:
         at_sender: bool = False,
         sender_id: str = "",
         send_source_group: Optional[str] = None,
+        recall: int = 0,
     ):
         return await self.bot.target_send(
             message,
@@ -742,6 +752,7 @@ class Bot:
             at_sender,
             sender_id,
             send_source_group,
+            recall=recall,
         )
 
 

--- a/gsuid_core/bot.py
+++ b/gsuid_core/bot.py
@@ -1,9 +1,11 @@
 import time
 import asyncio
 import inspect
+from uuid import uuid4
 from typing import Any, Dict, List, Union, Literal, Optional
 
 from fastapi import WebSocket
+from msgspec import to_builtins
 from msgspec import json as msgjson
 from starlette.websockets import WebSocketState
 
@@ -106,6 +108,7 @@ class _Bot:
         self.logger = GsLogger(self.bot_id, ws)
         self.queue = asyncio.queues.PriorityQueue()
         self.send_dict = {}
+        self.active_message_results: Dict[str, asyncio.Future] = {}
         self.bg_tasks: set[asyncio.Task] = set()
         self.sem = asyncio.Semaphore(10)
         self._shutdown_event: Optional[asyncio.Event] = None
@@ -202,6 +205,8 @@ class _Bot:
         task_id: str = "",
         task_event: Optional[asyncio.Event] = None,
         recall: int = 0,
+        active_message: bool = False,
+        wait_active_result: bool = False,
     ):
         # 记录 bot 回复到历史记录
         try:
@@ -346,6 +351,13 @@ class _Bot:
         elif recall > 120:
             recall = 120
 
+        send_id = ""
+        active_result_future = None
+        if active_message and wait_active_result:
+            send_id = uuid4().hex
+            active_result_future = asyncio.get_running_loop().create_future()
+            self.active_message_results[send_id] = active_result_future
+
         for mr in message_result:
             logger.trace("[GsCore][即将发送消息]", messages=_truncate_for_log(mr))
             if at_sender and sender_id:
@@ -361,10 +373,12 @@ class _Bot:
                 content=mr,
                 bot_id=bot_id,
                 bot_self_id=bot_self_id,
+                send_id=send_id,
                 target_type=target_type,
                 target_id=target_id,
                 msg_id=msg_id,
                 recall=recall,
+                active_message=active_message,
             )
 
             local_val = await get_global_val(bot_id, bot_self_id)
@@ -396,7 +410,10 @@ class _Bot:
             # ============================================
 
             logger.info(f"[发送消息to] {bot_id} - {target_type} - {target_id}")
-            body = msgjson.encode(send)
+            send_body = to_builtins(send)
+            if not send_id:
+                send_body.pop("send_id", None)
+            body = msgjson.encode(send_body)
             # 通过发送队列串行化 WebSocket 发送，避免多任务并发写入
             # 闭包不捕获 ws，执行时动态读取 self.bot，重连后自动使用新 ws
 
@@ -413,6 +430,19 @@ class _Bot:
             else:
                 # WS 模式：无论连没连都入队，worker 会等重连
                 await self._enqueue_send(_do_send())
+
+        if active_result_future is not None:
+            try:
+                return await asyncio.wait_for(active_result_future, timeout=15)
+            except asyncio.TimeoutError:
+                return None
+            finally:
+                self.active_message_results.pop(send_id, None)
+
+    def set_active_message_result(self, send_id: str, success: bool) -> None:
+        future = self.active_message_results.get(send_id)
+        if future is not None and not future.done():
+            future.set_result(success)
 
     async def wait_task(
         self,
@@ -558,7 +588,18 @@ class Bot:
         sep: str = "\n",
         command_tips: str = "请输入以下命令之一:",
         command_start_text: str = "",
+        active_message: bool = False,
+        wait_active_result: bool = False,
     ):
+        if option_list is None:
+            if reply:
+                return await self.send(
+                    reply,
+                    active_message=active_message,
+                    wait_active_result=wait_active_result,
+                )
+            return None
+
         return await self.receive_resp(
             reply,
             option_list,
@@ -716,6 +757,8 @@ class Bot:
         message: Union[Message, List[Message], str, bytes, List[str]],
         at_sender: bool = False,
         recall: int = 0,
+        active_message: bool = False,
+        wait_active_result: bool = False,
     ):
         return await self.bot.target_send(
             message,
@@ -730,6 +773,8 @@ class Bot:
             self.ev.task_id,
             self.ev.task_event,
             recall=recall,
+            active_message=active_message,
+            wait_active_result=wait_active_result,
         )
 
     async def target_send(
@@ -741,6 +786,8 @@ class Bot:
         sender_id: str = "",
         send_source_group: Optional[str] = None,
         recall: int = 0,
+        active_message: bool = False,
+        wait_active_result: bool = False,
     ):
         return await self.bot.target_send(
             message,
@@ -753,6 +800,8 @@ class Bot:
             sender_id,
             send_source_group,
             recall=recall,
+            active_message=active_message,
+            wait_active_result=wait_active_result,
         )
 
 

--- a/gsuid_core/core.py
+++ b/gsuid_core/core.py
@@ -146,6 +146,20 @@ async def main():
                             # 使用 wait_for 添加超时，以便定期检查 shutdown_event
                             data = await asyncio.wait_for(websocket.receive_bytes(), timeout=1.0)
                             msg = msgjson.decode(data, type=MessageReceive)
+                            if msg.send_id:
+                                for content in msg.content:
+                                    if content.type == "active_message_result":
+                                        result_data = content.data
+                                        if isinstance(result_data, dict) and "success" in result_data:
+                                            result = bool(result_data["success"])
+                                        else:
+                                            result = bool(result_data)
+                                        bot.set_active_message_result(
+                                            msg.send_id,
+                                            result,
+                                        )
+                                        break
+                                continue
                             await handle_event(bot, msg)
                         except asyncio.TimeoutError:
                             continue

--- a/gsuid_core/core.py
+++ b/gsuid_core/core.py
@@ -148,13 +148,13 @@ async def main():
                             msg = msgjson.decode(data, type=MessageReceive)
                             if msg.send_id:
                                 for content in msg.content:
-                                    if content.type == "active_message_result":
+                                    if content.type == "send_result":
                                         result_data = content.data
                                         if isinstance(result_data, dict) and "success" in result_data:
                                             result = bool(result_data["success"])
                                         else:
                                             result = bool(result_data)
-                                        bot.set_active_message_result(
+                                        bot.set_send_result(
                                             msg.send_id,
                                             result,
                                         )

--- a/gsuid_core/models.py
+++ b/gsuid_core/models.py
@@ -95,3 +95,4 @@ class MessageSend(Struct):
     target_type: Optional[str] = None
     target_id: Optional[str] = None
     content: Optional[List[Message]] = None
+    recall: int = 0

--- a/gsuid_core/models.py
+++ b/gsuid_core/models.py
@@ -98,4 +98,4 @@ class MessageSend(Struct):
     target_id: Optional[str] = None
     content: Optional[List[Message]] = None
     recall: int = 0
-    active_message: bool = False
+    wait_send_result: bool = False

--- a/gsuid_core/models.py
+++ b/gsuid_core/models.py
@@ -38,6 +38,7 @@ class MessageReceive(Struct):
     sender: Dict[str, Any] = {}
     user_pm: int = 6
     content: List[Message] = []
+    send_id: str = ""
 
 
 class Event(MessageReceive):
@@ -92,7 +93,9 @@ class MessageSend(Struct):
     bot_id: str = "Bot"
     bot_self_id: str = ""
     msg_id: str = ""
+    send_id: str = ""
     target_type: Optional[str] = None
     target_id: Optional[str] = None
     content: Optional[List[Message]] = None
     recall: int = 0
+    active_message: bool = False

--- a/gsuid_core/utils/database/models.py
+++ b/gsuid_core/utils/database/models.py
@@ -59,6 +59,8 @@ class Subscribe(BaseModel, table=True):
         command_tips: str = "请输入以下命令之一:",
         command_start_text: str = "",
         force_direct: bool = False,
+        active_message: bool = False,
+        wait_active_result: bool = False,
     ):
         if force_direct:
             user_type = "direct"
@@ -86,7 +88,14 @@ class Subscribe(BaseModel, table=True):
             if self.WS_BOT_ID in gss.active_bot:
                 BOT = gss.active_bot[self.WS_BOT_ID]
                 bot = Bot(BOT, ev)
-                await bot.send_option(**params)
+                if option_list:
+                    await bot.send_option(**params)
+                else:
+                    await bot.send(
+                        reply,
+                        active_message=active_message,
+                        wait_active_result=wait_active_result,
+                    )
             else:
                 # WS_BOT_ID 失效（可能重连后 ID 变了），尝试通过 bot_id 查找活跃 Bot
                 found = False
@@ -101,7 +110,14 @@ class Subscribe(BaseModel, table=True):
                             WS_BOT_ID=ws_bot_id,
                         )
                         bot = Bot(_bot, ev)
-                        await bot.send_option(**params)
+                        if option_list:
+                            await bot.send_option(**params)
+                        else:
+                            await bot.send(
+                                reply,
+                                active_message=active_message,
+                                wait_active_result=wait_active_result,
+                            )
                         found = True
                         break
                 if not found:
@@ -111,7 +127,14 @@ class Subscribe(BaseModel, table=True):
             for bot_id in gss.active_bot:
                 BOT = gss.active_bot[bot_id]
                 bot = Bot(BOT, ev)
-                await bot.send_option(**params)
+                if option_list:
+                    await bot.send_option(**params)
+                else:
+                    await bot.send(
+                        reply,
+                        active_message=active_message,
+                        wait_active_result=wait_active_result,
+                    )
 
 
 class CoreTag(BaseIDModel, table=True):

--- a/gsuid_core/utils/database/models.py
+++ b/gsuid_core/utils/database/models.py
@@ -59,8 +59,7 @@ class Subscribe(BaseModel, table=True):
         command_tips: str = "请输入以下命令之一:",
         command_start_text: str = "",
         force_direct: bool = False,
-        active_message: bool = False,
-        wait_active_result: bool = False,
+        wait_send_result: bool = False,
     ):
         if force_direct:
             user_type = "direct"
@@ -93,8 +92,7 @@ class Subscribe(BaseModel, table=True):
                 else:
                     await bot.send(
                         reply,
-                        active_message=active_message,
-                        wait_active_result=wait_active_result,
+                        wait_send_result=wait_send_result,
                     )
             else:
                 # WS_BOT_ID 失效（可能重连后 ID 变了），尝试通过 bot_id 查找活跃 Bot
@@ -115,8 +113,7 @@ class Subscribe(BaseModel, table=True):
                         else:
                             await bot.send(
                                 reply,
-                                active_message=active_message,
-                                wait_active_result=wait_active_result,
+                                wait_send_result=wait_send_result,
                             )
                         found = True
                         break
@@ -132,8 +129,7 @@ class Subscribe(BaseModel, table=True):
                 else:
                     await bot.send(
                         reply,
-                        active_message=active_message,
-                        wait_active_result=wait_active_result,
+                        wait_send_result=wait_send_result,
                     )
 
 


### PR DESCRIPTION
支持撤回，消息发送并等待结果参数，方便QQBot判断是否能够发送主动消息以及撤回某些消息

加了点有用的东西(´･ω･`)

## recall参数

适配器接收核心下发消息时，解析识别recall撤回参数；消息发送阶段同步追加对应平台适配的撤回参数，实现消息按指定时长自动撤回。

## wait_send_result参数

适配器接收核心下发消息时识别`wait_send_result`参数，待消息处理完成后向核心回传 `send_result` 结果

当插件侧调用：

```py
await bot.send("消息", wait_send_result=True)
```

核心会向适配器下发消息添加 `send_id` 和 `"wait_send_result": true` 

适配器收到消息后，正常解析参数并处理消息内容

待适配器消息处理完成后回传：

```json
{
  "send_id": "核心下发的 send_id",
  "content": [
    {
      "type": "send_result",
      "data": {
        "success": true
      }
    }
  ]
}
```

失败回传：
```json
{
  "send_id": "核心下发的 send_id",
  "content": [
    {
      "type": "send_result",
      "data": {
        "success": false,
        "error": "失败原因"
      }
    }
  ]
}

```

适配器返回内容经核心处理后向插件返回 `True` / `False` / `None`

插件调用以及接收状态示例：
```py
@sv.on_command("测试发送")
async def test_send(bot: Bot, ev: Event):
    result = await bot.send(
        "这是一条需要确认发送结果的消息",
        wait_send_result=True,
    )

    if result is True:
        await bot.send("✅ 消息发送成功")
    elif result is False:
        await bot.send("❌ 消息发送失败")
    else:
        await bot.send("⚠️ 消息发送结果超时")
```





