### PR TITLE
🐛 加固 to_process 进程池：worker 残留导致重启端口不释放 / Windows .pyd 被占用

### DIFF
--- a/gsuid_core/core.py
+++ b/gsuid_core/core.py
@@ -3,6 +3,7 @@ import sys
 import signal
 import asyncio
 import argparse
+import multiprocessing
 from typing import Dict
 from asyncio import CancelledError
 from pathlib import Path
@@ -222,4 +223,6 @@ async def main():
     await server.serve()
 
 
-asyncio.run(main())
+# 仅主进程启动服务(spawn 子进程重 import 本模块时跳过)
+if multiprocessing.current_process().name == "MainProcess":
+    asyncio.run(main())

--- a/gsuid_core/pool.py
+++ b/gsuid_core/pool.py
@@ -3,9 +3,9 @@ import sys
 import signal
 import asyncio
 import inspect
+import logging
 import functools
 import importlib
-import logging
 from typing import Any, TypeVar, Callable, Awaitable, Coroutine, ParamSpec, cast, overload
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 

--- a/gsuid_core/pool.py
+++ b/gsuid_core/pool.py
@@ -1,15 +1,53 @@
+import os
+import sys
+import signal
 import asyncio
 import inspect
 import functools
 import importlib
+import logging
 from typing import Any, TypeVar, Callable, Awaitable, Coroutine, ParamSpec, cast, overload
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
 
 T = TypeVar("T")
 P = ParamSpec("P")
 
+
+def _process_pool_initializer() -> None:
+    # fork worker 继承父进程已 bind 的监听 socket; 父进程被 kill 后内核 SIGKILL 本 worker, 防残留占端口
+    if sys.platform != "linux":
+        return
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.prctl.argtypes = [ctypes.c_int, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong, ctypes.c_ulong]
+        libc.prctl.restype = ctypes.c_int
+        if libc.prctl(1, signal.SIGKILL, 0, 0, 0) != 0:  # PR_SET_PDEATHSIG
+            err = ctypes.get_errno()
+            raise OSError(err, os.strerror(err))
+    except Exception as e:
+        logging.getLogger("gsuid_core").warning(f"[pool] PR_SET_PDEATHSIG 设置失败: {e}")
+
+
 _executor = ThreadPoolExecutor(max_workers=10)
-_process_executor = ProcessPoolExecutor()
+_process_executor = ProcessPoolExecutor(initializer=_process_pool_initializer)
+
+
+def shutdown_pools() -> None:
+    for ex in (_process_executor, _executor):
+        try:
+            ex.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            pass
+
+
+try:
+    from gsuid_core.server import on_core_shutdown
+
+    on_core_shutdown(shutdown_pools)
+except Exception:
+    pass
 
 
 @overload


### PR DESCRIPTION
`gsuid_core.pool.to_process` 用全局 `ProcessPoolExecutor()`。其 worker 在主进程退出/重启后不随之退出，引发下列问题：

## 症状（不修复的后果）
- **重启后监听端口不释放（Linux & Windows）**：残留 / 重跑的 worker 仍占着监听 socket，下次启动报 `address already in use`，需手动杀进程后再重启才能恢复。
- **Windows 下编译产物 `.pyd` 被占用、无法替换**：残留 worker 进程仍加载着旧 `.pyd`，构建更新时 `os.replace` 撞「文件被占用」、替换失败（PermissionError）。
- 根因：`to_process` 进程池 worker 没有随主进程一起退出（fork 还继承了主进程的监听 socket fd）。

## 改动

### 1. `pool.py` — fork worker 残留（Linux）
- fork worker 继承主进程已 bind 的监听 socket fd（CLOEXEC 对纯 fork 无效）；主进程被 `kill -9`（如自带 core 重启）后 worker 不退出（继承 call_queue 写端、收不到 EOF），持续占端口 / 占 `.pyd`。
- 修复：进程池加 `initializer`，worker 内设 `PR_SET_PDEATHSIG`（仅 Linux），父进程一死内核立即 `SIGKILL` 该 worker；失败仅告警、不弄坏池。
- 另加 `shutdown_pools()` 注册到 `on_core_shutdown`，优雅关闭时收掉进程/线程池（跨平台兜底，释放 Windows 上被 worker 占用的 `.pyd`）。

### 2. `core.py` — spawn/forkserver worker 重跑服务
- spawn/forkserver worker bootstrap 会重新 import `__main__`，触发模块顶层 `asyncio.run(main())` → worker 里又启一遍服务器（重绑端口报错）。
- 修复：`asyncio.run(main())` 仅在 `MainProcess` 执行。

## 影响
Linux(fork) 行为不变；Windows / forkserver（Py3.14 默认）下 `to_process` 不再因 worker 残留/重跑而占端口、占 `.pyd` 或重起服务。
