### PR TITLE
📦 显式声明 markdown-it-py>=4.2.0 直接依赖

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2683,14 +2683,14 @@ testing = ["coverage", "pyyaml"]
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147"},
-    {file = "markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"},
+    {file = "markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"},
+    {file = "markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49"},
 ]
 
 [package.dependencies]
@@ -2703,7 +2703,7 @@ linkify = ["linkify-it-py (>=1,<3)"]
 plugins = ["mdit-py-plugins (>=0.5.0)"]
 profiling = ["gprof2dot"]
 rtd = ["ipykernel", "jupyter_sphinx", "mdit-py-plugins (>=0.5.0)", "myst-parser", "pyyaml", "sphinx", "sphinx-book-theme (>=1.0,<2.0)", "sphinx-copybutton", "sphinx-design"]
-testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "requests"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions", "pytest-timeout", "requests"]
 
 [[package]]
 name = "markdownify"
@@ -6342,4 +6342,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "f1dc24a0a309ded4c8504b59075958be8ba3db0067286a84b61d42321bd95575"
+content-hash = "74da773778826c2d5b5a97de4f5582c25b83a33d53d0f2c3ee4bb684c410b033"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
     "markdownify>=1.2.2",
     "onnxruntime>=1.24.1",
     "pyhtmlrender>=0.1.6",
+    "markdown-it-py>=4.2.0",
 ]
 name = "gsuid-core"
 version = "0.10.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1143,10 +1143,12 @@ markdown==3.10.2 \
     # via
     #   pyhtmlrender
     #   pymdown-extensions
-markdown-it-py==4.0.0 \
-    --hash=sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147 \
-    --hash=sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3
-    # via rich
+markdown-it-py==4.2.0 \
+    --hash=sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49 \
+    --hash=sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+    # via
+    #   gsuid-core
+    #   rich
 markdownify==1.2.2 \
     --hash=sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a \
     --hash=sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09

--- a/uv.lock
+++ b/uv.lock
@@ -1239,6 +1239,7 @@ dependencies = [
     { name = "json-repair" },
     { name = "lmdb" },
     { name = "lxml" },
+    { name = "markdown-it-py" },
     { name = "markdownify" },
     { name = "mpmath" },
     { name = "msgspec" },
@@ -1306,6 +1307,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.59.4" },
     { name = "lmdb", specifier = ">=1.7.5" },
     { name = "lxml", specifier = ">=4.9.2" },
+    { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "markdownify", specifier = ">=1.2.2" },
     { name = "mpmath", specifier = ">=1.3.0,<2.0.0" },
     { name = "msgspec", specifier = ">=0.13.1" },
@@ -1957,14 +1959,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

`rich` 间接拉入 `markdown-it-py` 但未指定版本下界，`uv lock` 早期解析时把 `markdown-it-py` 锁到 `4.0.0`。后续 `markdown-it-py` 4.1.0+ 出来后带了：

- 内置 GFM `> [!NOTE]` alerts
- 内置 tasklists (`md.options['tasklists'] = True`)

这些是 `mdit_py_plugins.gfm.gfm_plugin` 必需的能力（4.1.0 才支持，否则 `RuntimeError: gfm_plugin requires markdown-it-py >= 4.1.0`）。

但下游插件（如 CCUID 等 markdown 渲染场景）即使在自己的 `pyproject` 声明 `markdown-it-py>=4.1.0` 也无效——`uv sync` 按 gscore 主仓 lockfile 走，把版本压回 4.0.0。

## 改动

`pyproject.toml` 增加一行直接依赖：

```toml
"markdown-it-py>=4.2.0",
```

`uv.lock` / `poetry.lock` / `requirements.txt` 重新解析后同步升到 4.2.0。

## 兼容性

- `rich` 14.x 完全兼容 `markdown-it-py` 4.x（无上界约束）
- 其它间接依赖路径未变化
- 解决下游插件想用 GFM alerts / 严格 GFM 表格行为时的依赖瓶颈

## 测试

- [x] `uv lock` 无冲突
- [x] `poetry lock` 通过 pre-commit hook
- [x] `uv sync` 后 import 链路验证：`from gsuid_core.ai_core.mcp.client import MCPClient` 正常
- [x] markdown-it-py 4.2.0 在 venv 中实际可用，`from mdit_py_plugins.gfm import gfm_plugin` 不再 raise RuntimeError