### PR TITLE
📦 抽离 docker 基础镜像 简化部署配置

### DIFF
--- a/.cnb.yml
+++ b/.cnb.yml
@@ -9,7 +9,12 @@ master:
             rootlessBuildkitd:
               enabled: true
       env:
+        BASE_TAG: ${CNB_DOCKER_REGISTRY}/${CNB_REPO_SLUG_LOWERCASE}/gscore-uv-3.12:latest
         IMAGE_TAG: ${CNB_DOCKER_REGISTRY}/${CNB_REPO_SLUG_LOWERCASE}:latest
       stages:
-        - name: playwright
+        - name: build base
+          ifModify:
+            - "docker/base/**"
+          script: docker buildx build -t ${BASE_TAG} --platform linux/amd64,linux/arm64 --push -f docker/base/Dockerfile docker/base/
+        - name: build bundle
           script: docker buildx build --target bundle -t ${IMAGE_TAG} --platform linux/amd64,linux/arm64 --push -f Dockerfile .

--- a/.env.example
+++ b/.env.example
@@ -18,13 +18,6 @@ PORT=8765
 # 中国科学技术大学: https://pypi.mirrors.ustc.edu.cn/simple/
 GSCORE_PYTHON_INDEX=https://pypi.org/simple/
 
-# 使项目不再读取 pyproject.toml 配置，从而使用自定义 python 镜像
-# 开启后会读取 GSCORE_PYTHON_INDEX 作为镜像源
-# 0：关闭 1：开启
-# ⚠️注意：该操作会导致 uv.lock 发生 git diff 改动；
-UV_NO_CONFIG=0
-
-
 # ===========================
 # 挂载模式配置
 # ===========================
@@ -33,10 +26,8 @@ UV_NO_CONFIG=0
 # 默认: 当前目录 (.)
 MOUNT_PATH=.
 
-# 镜像配置
-# 原始镜像 astral/uv:python3.12-bookworm-slim
-# cnb.cool 镜像 docker.cnb.cool/gscore-mirror/docker-sync/astral-uv:python3.12-bookworm-slim
-GSCORE_BASE_IMAGE=docker.cnb.cool/gscore-mirror/docker-sync/astral-uv:python3.12-bookworm-slim
+# 镜像配置 (gsuid_core 自建基础镜像,含 Python+uv+playwright+chromium+字体)
+GSCORE_BUILTIN_BASE=docker.cnb.cool/gscore-mirror/gsuid_core/gscore-uv-3.12:latest
 
 # ===========================
 # 全量模式配置

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,97 +1,33 @@
-# ==========================================
-# Stage 0: 参数
-# ==========================================
-# 原始镜像 astral/uv:python3.12-bookworm-slim
-# cnb.cool 镜像 docker.cnb.cool/gscore-mirror/docker-sync/astral-uv:python3.12-bookworm-slim
+# gsuid_core 业务镜像
+# 基于 docker/base/Dockerfile 预构建的基础镜像(已包含 Python+uv+playwright+chromium+字体)
 
-# 定义基础镜像的参数
-ARG GSCORE_BASE_IMAGE=docker.cnb.cool/gscore-mirror/docker-sync/astral-uv:python3.12-bookworm-slim
-
-# 定义 Python 镜像源
+ARG GSCORE_BUILTIN_BASE=docker.cnb.cool/gscore-mirror/gsuid_core/gscore-uv-3.12:latest
 ARG GSCORE_PYTHON_INDEX=https://pypi.org/simple
 
 # ==========================================
-# Stage 1: Base (最基础的系统环境)
-# 包含：Python, 时区, 编译工具, Git, 空虚拟环境
+# Runtime: 代码 + venv 通过 volume 挂载,镜像只提供环境
 # ==========================================
-FROM ${GSCORE_BASE_IMAGE} AS base
+FROM ${GSCORE_BUILTIN_BASE} AS runtime
 
-# 暴露端口 (放在最上面)
 EXPOSE 8765
-
 WORKDIR /gsuid_core
 
-# 环境变量
-ENV UV_PROJECT_ENVIRONMENT=/venv
-ENV PATH="/venv/bin:$PATH"
-ENV UV_LINK_MODE=copy
-
-# 1. 安装最基础的系统依赖
-# 2. 创建虚拟环境
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    curl \
-    gcc \
-    python3-dev \
-    build-essential \
-    tzdata \
-    && ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
-    && echo Asia/Shanghai > /etc/timezone \
-    && uv venv /venv --seed \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# 配置 git safe.directory
-RUN git config --global --add safe.directory '*'
-
-# ==========================================
-# Stage 2: Playwright Base (浏览器环境层)
-# 包含：Chromium, 中文字体, Python Playwright 库(已安装在 venv)
-# ==========================================
-FROM base AS playwright_base
-
-# 再次声明 Python 镜像源
-ARG GSCORE_PYTHON_INDEX
-
-# 设置浏览器全局路径
-ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
-
-# 1. 安装 Playwright 运行所需的额外依赖 (中文字体 + 浏览器依赖)
-# 2. 下载 Chromium 及其依赖
-RUN --mount=type=cache,target=/root/.cache/uv \
-    apt-get update && apt-get install -y --no-install-recommends \
-    fonts-noto-cjk \
-    libffi-dev \
-    && uv pip install playwright --index ${GSCORE_PYTHON_INDEX} \
-    && playwright install --with-deps chromium \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
-# ==========================================
-# Stage 3: Runtime (挂载模式)
-# 继承自 playwright_base
-# ==========================================
-FROM playwright_base AS runtime
-
-# 启动命令
 CMD ["uv", "run", "--python", "/venv/bin/python", "core", "--host", "0.0.0.0"]
 
 # ==========================================
-# Stage 4: Bundle (全量模式)
-# 继承自 playwright_base
+# Bundle: 代码 + 依赖一起打入镜像
 # ==========================================
-FROM playwright_base AS bundle
+FROM ${GSCORE_BUILTIN_BASE} AS bundle
 
-# 再次声明 Python 镜像源
 ARG GSCORE_PYTHON_INDEX
+EXPOSE 8765
+WORKDIR /gsuid_core
 
-# 1. 复制项目依赖，不要lock文件
 COPY pyproject.toml README.md ./
 
-# 2. 应用自定义镜像源
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --index ${GSCORE_PYTHON_INDEX}
 
-# 3. 复制项目代码
 COPY . .
 
-# 4. 启动命令
 CMD ["uv", "run", "--python", "/venv/bin/python", "core", "--host", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker-compose up -d --build
 
 4. **管理**
    - 服务运行在端口 `8765`。
-   - 启动后可通过 `localhost:8765/genshinuid` 进入核心的后台管理界面
+   - 启动后可通过 `localhost:8765/app` 进入核心的后台管理界面
 
 ---
 
@@ -90,7 +90,7 @@ docker-compose up -d --build
 cp .env.example .env
 ```
 
-2. **启动服务**
+3. **启动服务**
 
    **方式 A：Docker Compose (推荐)**
 
@@ -113,14 +113,13 @@ cp .env.example .env
 
    _(会自动拉取全量镜像)_
 
-3. **数据管理**
-
+4. **数据管理**
    - 数据持久化在 `/opt/gscore_data` 目录。
    - 自定义插件可放在 `/opt/gscore_plugins` 目录。
 
-4. **管理**
+5. **管理**
    - 服务运行在端口 `8765`。
-   - 启动后可通过 `localhost:8765/genshinuid` 进入核心的后台管理界面
+   - 启动后可通过 `localhost:8765/app` 进入核心的后台管理界面
 
 ---
 

--- a/docker-compose.bundle.yml
+++ b/docker-compose.bundle.yml
@@ -20,8 +20,7 @@ services:
 
     environment:
       - PYTHONUNBUFFERED=1
-      - UV_INDEX=${GSCORE_PYTHON_INDEX:-}
-      - UV_NO_CONFIG=${UV_NO_CONFIG:-false}
+      - UV_DEFAULT_INDEX=${GSCORE_PYTHON_INDEX:-}
       - UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-120}
       - http_proxy=${GSCORE_HTTP_PROXY:-}
       - https_proxy=${GSCORE_HTTPS_PROXY:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: .
       target: ${GSCORE_BUILD_TARGET:-runtime}
       args:
-        - GSCORE_BASE_IMAGE=${GSCORE_BASE_IMAGE:-docker.cnb.cool/gscore-mirror/docker-sync/astral-uv:python3.12-bookworm-slim}
+        - GSCORE_BUILTIN_BASE=${GSCORE_BUILTIN_BASE:-docker.cnb.cool/gscore-mirror/gsuid_core/gscore-uv-3.12:latest}
         - GSCORE_PYTHON_INDEX=${GSCORE_PYTHON_INDEX:-https://pypi.org/simple}
 
     image: gsuid-core:${GSCORE_BUILD_TARGET:-runtime}
@@ -17,13 +17,12 @@ services:
     volumes:
       - ${MOUNT_PATH:-.}:/gsuid_core
       - venv-data:/venv
-    restart: unless-stopped
+    restart: always
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
       - PYTHONUNBUFFERED=1
-      - UV_INDEX=${GSCORE_PYTHON_INDEX:-}
-      - UV_NO_CONFIG=${UV_NO_CONFIG:-false}
+      - UV_DEFAULT_INDEX=${GSCORE_PYTHON_INDEX:-}
       - UV_HTTP_TIMEOUT=${UV_HTTP_TIMEOUT:-120}
       - http_proxy=${GSCORE_HTTP_PROXY:-}
       - https_proxy=${GSCORE_HTTPS_PROXY:-}

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,26 @@
+# gsuid-base
+# 业务镜像 FROM 此镜像,避免重复下载 Chromium 和系统包。
+# 升级 Python / Playwright / 字体时改这里并重建。
+
+FROM astral/uv:python3.12-bookworm-slim
+
+ENV UV_PROJECT_ENVIRONMENT=/venv \
+    PATH="/venv/bin:$PATH" \
+    UV_LINK_MODE=copy \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+
+# 系统依赖 + 时区 + git safe.directory + 空 venv
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl gcc python3-dev build-essential libffi-dev \
+    fonts-noto-cjk tzdata \
+    && ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
+    && echo Asia/Shanghai > /etc/timezone \
+    && git config --global --add safe.directory '*' \
+    && uv venv /venv --seed \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Playwright Python 包 + Chromium 及其浏览器依赖
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install playwright \
+    && playwright install --with-deps chromium \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

抽离 docker 基础镜像独立构建,业务 Dockerfile 从 97 行精简到 33 行,同步清理部署相关配置。

### 关键改动

- **新增 `docker/base/Dockerfile`**:把原 `base` + `playwright_base` 两个 stage 合并为独立基础镜像(Python + uv + 系统包 + 中文字体 + Playwright Chromium)
- **`.cnb.yml`**:在同一 pipeline 内新增 `build base` stage,通过 `ifModify: ["docker/base/**"]` 仅在 base 文件变化时触发;`build bundle` stage 顺序紧随其后,避免并行 race
- **业务 `Dockerfile`**:`FROM` 新基础镜像,保留 runtime 和 bundle 两个 target,行数 97 → 33
- **环境变量整理**:
  - `GSCORE_BASE_IMAGE` → `GSCORE_BUILTIN_BASE`(语义区分:旧变量指上游镜像,新变量指自建基础镜像;同时避免历史 `.env` 冲突)
  - 移除 `UV_NO_CONFIG`(无实际用途,设 true 反而会破坏 uv 配置读取)
  - `UV_INDEX` → `UV_DEFAULT_INDEX`(语义修正:`UV_INDEX` 是追加 additional index,`UV_DEFAULT_INDEX` 才是替换 default)
- **`README.md`**:修正"模式二"步骤序号(2→3→4→5);后台路径 `/genshinuid` → `/app`

### 收益

- base 镜像与业务变更解耦:升级 Python / Playwright / 字体只需重建 base
- CNB 构建时间显著缩短:不再每次重下 Chromium + apt 包
- 业务 Dockerfile 行数 -47%(97 → 33)
- pypi 镜像加速配置语义正确

### Breaking Changes

- 历史 `.env` 里的 `GSCORE_BASE_IMAGE` 不再生效,需改名为 `GSCORE_BUILTIN_BASE`
- 历史 `.env` 里的 `UV_NO_CONFIG` 已不被读取(无害,可直接删除)

## Test plan

- [ ] CNB `build base` pipeline 触发,推送 `docker.cnb.cool/gscore-mirror/gsuid_core/gscore-uv-3.12:latest` 成功
- [ ] CNB `build bundle` pipeline FROM 新 base 构建并推送业务镜像成功
- [ ] 本地 runtime 模式 `docker compose up -d` 启动正常
- [ ] 本地 bundle 模式 `docker compose -f docker-compose.bundle.yml up -d` 拉取并启动正常
- [ ] 截图功能(Playwright / Chromium)可用