### PR TITLE
🐛 修复 WS 重连后 _process 消费者泄漏（gather 永不退出）

### DIFF
--- a/gsuid_core/core.py
+++ b/gsuid_core/core.py
@@ -161,16 +161,30 @@ async def main():
                     await gss.disconnect(bot_id)
 
             async def process():
-                """process 函数的职责是启动 bot._process，由 _process 内部处理 shutdown"""
                 try:
                     await bot._process(shutdown_event)
                 except CancelledError:
                     pass
 
             logger.info("[GsCore] 启动WS服务中...")
-            await asyncio.gather(process(), start())
-        except CancelledError:
-            await gss.disconnect(bot_id)
+            # 任一结束(通常是 start 断连返回)即取消另一个, 避免 _process 残留消费同一队列
+            process_task = asyncio.create_task(process())
+            start_task = asyncio.create_task(start())
+            try:
+                await asyncio.wait(
+                    {process_task, start_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                for _t in (process_task, start_task):
+                    if not _t.done():
+                        _t.cancel()
+                # 取回两个子任务结果, 避免 "exception never retrieved" 告警
+                _results = await asyncio.gather(process_task, start_task, return_exceptions=True)
+            # 子任务有真实异常(非取消)则向上抛; 放在 finally 外, 不吞外层取消
+            for _r in _results:
+                if isinstance(_r, BaseException) and not isinstance(_r, CancelledError):
+                    raise _r
         finally:
             await gss.disconnect(bot_id)
 

--- a/gsuid_core/server.py
+++ b/gsuid_core/server.py
@@ -519,6 +519,12 @@ class GsServer:
             # 已经断开过了，幂等返回
             return
 
+        # ws 已移除且实例已标记断连(保留等待重连)时, 重复调用幂等返回, 避免重复清理与告警
+        if bot_id not in self.active_ws:
+            _retained = self.active_bot.get(bot_id)
+            if _retained is not None and getattr(_retained, "_disconnected_at", None) is not None:
+                return
+
         from gsuid_core.bot import Bot
 
         if bot_id in self.active_ws:


### PR DESCRIPTION
## 问题
`gsuid_core/core.py` 的 websocket_endpoint 用 `await asyncio.gather(process(), start())`
同时等待接收循环与命令队列消费：

- `start()`（接收循环）在 `WebSocketDisconnect` 时 break 返回，并在 finally 里 disconnect；
- `process()` = `await bot._process(shutdown_event)`，而 `_Bot._process` 是 `while True`，
  **只在 shutdown_event 置位时退出**，断连不退出。

于是适配器断连后 `gather` 永不返回：旧 endpoint 协程卡死在 gather 上；而 `GsServer.connect`
重连时复用同一个 `_Bot`（同一个 `bot.queue`），每次重连都再起一个 `process()`/`_process`。
**反复重启/重连后，同一队列上堆积越来越多空转的 _process 消费者 + 泄漏的 endpoint 协程。**

## 改动
**core.py**
- `gather(...)` → `asyncio.wait({process_task, start_task}, return_when=FIRST_COMPLETED)`，
  任一结束即取消另一个，并用 `gather(..., return_exceptions=True)` 回收，避免子任务异常未被
  retrieve 的告警；
- 移除吞掉 `CancelledError` 的外层 except，cleanup 留在 finally，使优雅关闭的取消能正常向上
  传播；子任务的真实异常在 finally 外重新抛出（不吞外层取消）。

**server.py**
- `GsServer.disconnect` 增加「ws 已移除且实例已标记断连」的幂等早返回——本次改动会让 `start()`
  的 finally 与 endpoint 外层 finally 都走到 disconnect，早返回避免重复清理与重复告警。

## 影响
- 正常断连：start_task 结束 → process_task 被取消回收 → 单次 disconnect，无泄漏。
- 重连：复用 _Bot 仍只有**一个** _process 消费者；队列中未消费的命令由新消费者继续处理。
- 优雅关闭：shutdown_event 置位，两子任务正常退出；外层取消不再被吞。
- 不改变命令处理 / 发送语义。

## 验证
- 三轮独立代码评审（取消传播、重连单消费者、disconnect 幂等、子任务异常回收等边界）。
- 本地 py_compile 通过。

未涉及（既有、独立问题）：_safe_run 任务未登记、出队与 _safe_run 创建间的取消窗口、
重连/断连并发覆写 active_ws 等。
