### PR TITLE
✨ 配置项支持 secret 标记，查看配置时隐藏敏感值

### DIFF
--- a/gsuid_core/buildin_plugins/core_command/core_config_cmd/_render.py
+++ b/gsuid_core/buildin_plugins/core_command/core_config_cmd/_render.py
@@ -24,6 +24,8 @@ def _join(lst) -> str:
 
 def fmt_val(item: GSC, key: str = "") -> str:
     """格式化配置项的值, 敏感字段脱敏"""
+    if getattr(item, "secret", False):
+        return "<已隐藏>"
     if isinstance(item, GsBoolConfig):
         return "开启" if item.data else "关闭"
     if isinstance(item, GsTimeRConfig):

--- a/gsuid_core/utils/plugins_config/gs_config.py
+++ b/gsuid_core/utils/plugins_config/gs_config.py
@@ -278,6 +278,7 @@ class StringConfig:
 
                     self.config[key].title = _defalut.title
                     self.config[key].desc = _defalut.desc
+                    self.config[key].secret = _defalut.secret
 
         """
         # 对默认值没有的值，直接删除

--- a/gsuid_core/utils/plugins_config/models.py
+++ b/gsuid_core/utils/plugins_config/models.py
@@ -11,35 +11,42 @@ class GsConfig(msgspec.Struct, tag=True):
 class GsStrConfig(GsConfig, tag=True):
     data: str
     options: List[str] = []
+    secret: bool = False
 
 
 class GsBoolConfig(GsConfig, tag=True):
     data: bool
+    secret: bool = False
 
 
 class GsDictConfig(GsConfig, tag=True):
     data: Dict[str, List]
+    secret: bool = False
 
 
 class GsListStrConfig(GsConfig, tag=True):
     data: List[str]
     options: List[str] = []
+    secret: bool = False
 
 
 class GsListConfig(GsConfig, tag=True):
     data: List[int]
+    secret: bool = False
 
 
 class GsIntConfig(GsConfig, tag=True):
     data: int
     max_value: Optional[int] = None
     options: List[int] = []
+    secret: bool = False
 
 
 class GsFloatConfig(GsConfig, tag=True):
     data: float
     min_value: Optional[float] = None
     max_value: Optional[float] = None
+    secret: bool = False
 
 
 class GsImageConfig(GsConfig, tag=True):
@@ -47,16 +54,19 @@ class GsImageConfig(GsConfig, tag=True):
     upload_to: str
     filename: str
     suffix: str = "jpg"
+    secret: bool = False
 
 
 class GsTimeRConfig(GsConfig, tag=True):
     data: Tuple[int, int]
+    secret: bool = False
 
 
 class GsTimeConfig(GsConfig, tag=True):
     """deprecated/已废弃"""
 
     data: str
+    secret: bool = False
 
 
 GSC = Union[


### PR DESCRIPTION
## 这是什么

为 `GsConfig` 系列配置结构体新增 `secret: bool = False` 字段。插件作者可把某个配置项声明为敏感项：

```python
"WavesToken": GsStrConfig("鸣潮全排行token", "...", "", secret=True),
```

被标记的项，在 **`查看配置`** 的列表 / 详情 / 设置回显中统一显示为 `<已隐藏>`；但 **`设置配置`** 指令完全照常可用（仍可设置，只是不回显值）。

## 为什么

当前 `fmt_val` 只按键名子串（`token`/`key`/`secret`/`password`/`密钥` 等）做**部分脱敏**（露出头尾各 2 位）。问题：

- 带 auth 的 URL、登录地址、外置渲染地址、字体 CSS 地址、面板编辑密码等，**键名往往不含上述敏感词**，于是 `查看配置 xxx` 会把完整值直接回显到群里 → 泄露风险；
- 即便命中，头尾各 2 位对短密钥仍是泄露。

`secret=True` 提供一个**显式、完全隐藏**的开关，不依赖对键名的猜测，把"是否敏感"的判断权交还给最了解该配置语义的插件作者。

## 实现

- **`models.py`**：`secret` 作为各**具体子类**的末位字段加入（而非基类 `GsConfig`）。原因：msgspec 不允许基类的带默认值字段排在子类必填字段之前（会 `TypeError`），而 `kw_only=True` 会破坏现有大量 `GsXConfig("title","desc","data")` 位置参数调用。放末位既满足"可选字段在必填之后"，又保持位置构造不变。
- **`gs_config.py`**：`update_config` 合并时，`secret` 与 `title`/`desc` 一样从**代码默认值刷新**——它是定义元数据而非用户数据，这样旧 `config.json` 不会固化过期值。
- **`_render.py`**：`fmt_val` 入口判定 `secret`，命中即返回 `<已隐藏>`。这是列表 / 详情 / 设置回显三处共用的唯一渲染收口，单点改动即可全覆盖。

## 向后兼容

旧 `config.json` 没有 `secret` 键，msgspec 解码时默认 `False`，不会触发 `ValidationError` → `repair_config` 重置。已在本地验证：旧 json 正常解码、secret 项隐藏、普通项不受影响、位置参数构造仍可用。

## 给作者的建议 📌

建议在**配置说明文档**里补充 `secret=True` 这个新选项，并提示插件作者：**凡是带鉴权信息的 URL / token / 密码 / 登录地址等，应显式标记 `secret=True`**，以免后续再出现"带 auth 的 url 被 `查看配置` 直接回显导致泄露"的问题。这样新写的插件能从一开始就规避该坑，而不必依赖核心去猜键名。