### PR TITLE
🐛 scheduled_job 忽略冗余的 replace_existing 传参

### DIFF
--- a/gsuid_core/aps.py
+++ b/gsuid_core/aps.py
@@ -19,7 +19,15 @@ options = {
     "job_defaults": job_defaults,
     "timezone": "Asia/Shanghai",
 }
-scheduler = AsyncIOScheduler()
+
+
+class _GsScheduler(AsyncIOScheduler):
+    def scheduled_job(self, *args, **kwargs):
+        kwargs.pop("replace_existing", None)
+        return super().scheduled_job(*args, **kwargs)
+
+
+scheduler = _GsScheduler()
 scheduler.configure(options)
 
 # 延迟导入避免循环导入


### PR DESCRIPTION
`AsyncIOScheduler.scheduled_job` 装饰器内部已固定用 `replace_existing=True` 调 `add_job`。插件若再传一次 `replace_existing`，会报 `add_job() got multiple values for argument 'replace_existing'`，导致整个插件 `__init__` 导入失败。

子类重写 `scheduled_job` 把这个冗余 kwarg 剥掉即可，行为不变（仍替换同 id 任务）。

实测 AI 写定时任务时非常喜欢顺手加 `replace_existing=True`，框架层自动去除比让每个插件作者都去记这个坑更优雅。