### PR TITLE
🐛 修复文件上传触发器把文件 base64 整段写入日志

### DIFF
--- a/gsuid_core/logger.py
+++ b/gsuid_core/logger.py
@@ -12,8 +12,8 @@ from functools import wraps
 from dataclasses import dataclass
 from logging.handlers import TimedRotatingFileHandler
 
-import aiofiles
 import msgspec
+import aiofiles
 import structlog
 from colorama import Fore, Style, init
 from structlog.dev import ConsoleRenderer

--- a/gsuid_core/logger.py
+++ b/gsuid_core/logger.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from logging.handlers import TimedRotatingFileHandler
 
 import aiofiles
+import msgspec
 import structlog
 from colorama import Fore, Style, init
 from structlog.dev import ConsoleRenderer
@@ -509,6 +510,36 @@ def reduce_message(messages: List[Message]):
     return mes
 
 
+def _shorten_b64(value: Optional[str]) -> Optional[str]:
+    """超长字符串(文件/图片 base64)只保留长度提示，避免整段写入日志。"""
+    if isinstance(value, str) and len(value) > 256:
+        return f"<{len(value)} chars omitted>"
+    return value
+
+
+def reduce_event_dict(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
+    """防止 Event / 超长字段被完整写入日志(file + console + collect 三个 sink 通用)。
+
+    文件上传触发器(on_file)下 ``get_command`` 返回的 Event 里 ``file`` 存着整份
+    base64，``logger.info("[命令触发]", command=message)`` 会把它原样落盘。这里统一裁剪。
+    """
+    for key, value in list(event_dict.items()):
+        if isinstance(value, Event):
+            try:
+                event_dict[key] = msgspec.structs.replace(
+                    value,
+                    task_event=None,
+                    content=reduce_message(value.content),
+                    file=_shorten_b64(value.file),
+                    image=_shorten_b64(value.image),
+                )
+            except Exception:
+                event_dict[key] = f"<Event uid={value.user_id} gid={value.group_id} cmd={value.command!r}>"
+        elif isinstance(value, str) and len(value) > 4096:
+            event_dict[key] = value[:256] + f"…<{len(value)} chars truncated>"
+    return event_dict
+
+
 def format_event_for_console(logger: WrappedLogger, method_name: str, event_dict: EventDict) -> EventDict:
     event: Optional[Event] = deepcopy(event_dict.get("event_payload"))
     if isinstance(event, Event):
@@ -664,6 +695,7 @@ def setup_logging():
         structlog.processors.StackInfoRenderer(),
         # structlog.processors.format_exc_info,
         structlog.processors.TimeStamper(fmt="%m-%d %H:%M:%S", utc=False),
+        reduce_event_dict,
     ]
 
     if IS_DEBUG_LOG:

--- a/gsuid_core/security_manager.py
+++ b/gsuid_core/security_manager.py
@@ -85,10 +85,10 @@ class AuthRateLimiter:
         # key -> 封禁到期时间戳
         self._ban_until: DefaultDict[str, float] = defaultdict(float)
 
-        self.WINDOW = 60.0          # 滑动窗口长度（秒）
-        self.MAX_ATTEMPTS = 10      # 窗口内允许的最大请求次数
-        self.MAX_FAILURES = 5       # 触发封禁的连续失败次数
-        self.BAN_DURATION = 900.0   # 封禁时长（秒）
+        self.WINDOW = 60.0  # 滑动窗口长度（秒）
+        self.MAX_ATTEMPTS = 10  # 窗口内允许的最大请求次数
+        self.MAX_FAILURES = 5  # 触发封禁的连续失败次数
+        self.BAN_DURATION = 900.0  # 封禁时长（秒）
 
     def check(self, key: str) -> Tuple[bool, int]:
         """检查本次请求是否允许。


### PR DESCRIPTION
## 问题

通过 `on_file` 注册的文件上传触发器(如鸣潮抽卡记录 json 导入)被命中时,核心会把整份上传文件的 base64 写进日志文件。

复现:向任意 `on_file("json")` 这类触发器上传一个文件,`data/logs/YYYY-MM-DD.log` 里会出现一条 `{"command": "Event(... file='<整段 base64>' ...)"}`。

## 根因

- `handler.py` 中 `logger.info("[命令触发]", command=message)`,而 `Trigger.get_command()` 返回的就是 `Event`;文件触发器下 `event.file` 存着整份 base64(`file_type='base64'`)。
- 日志管线里只有 console sink 经过 `format_event_for_console`,而 **file sink(`file_processors`)直接 `JSONRenderer`**,没有任何 Event 脱敏步骤,于是 `command` 这个 Event 被整体序列化落盘;同时 `format_event_for_console` 也只洗 `event_payload`/`messages`,不洗 `command`,所以控制台同样会漏。

## 改动

新增一个 **shared 处理器** `reduce_event_dict`(file/console/collect 三个 sink 通用),统一把日志 `event_dict` 里任何 `Event` 值的 `file`/`image` base64 与超长字段裁剪掉:

- `file`/`image` 超过 256 字符 → 替换为 `<N chars omitted>`;
- `content` 复用既有的 `reduce_message` 截断;
- 用 `msgspec.structs.replace(..., task_event=None)` 做浅拷贝,避免 deepcopy `asyncio.Event`;
- 兜底:replace 异常时退化为紧凑摘要;非 Event 的超长字符串(>4096)也截断。

不改变正常文字命令的日志内容,仅裁剪超长/二进制字段。