### PR TITLE
🐛 修复 exec_list 迁移单条失败污染事务导致后续迁移被整体跳过

### DIFF
--- a/gsuid_core/utils/database/startup.py
+++ b/gsuid_core/utils/database/startup.py
@@ -162,5 +162,7 @@ async def trans_adapter():
             try:
                 await session.execute(text(_t))
                 await session.commit()
-            except:  # noqa: E722
-                pass
+            except Exception as e:
+                # 单条失败必须 rollback, 否则事务被污染会导致其后语句被整体跳过
+                await session.rollback()
+                logger.debug(f"[数据库] 迁移语句跳过: {_t} ({e})")


### PR DESCRIPTION
## 问题

插件通过 `from gsuid_core.utils.database.startup import exec_list; exec_list.extend([...])` 注册数据库迁移（多为 `ALTER TABLE ... ADD COLUMN`，靠 `try/except` 实现幂等）。

`trans_adapter`（`@on_core_start_before(priority=-80)`）逐条执行 `exec_list`，但 `except` 只 `pass`、**不 rollback**。当某条语句失败时（例如重复 `ADD COLUMN` 已存在的列、`DROP COLUMN` 不存在的列，或个别后端语法不兼容），async session 的事务进入 aborted 状态，**其后每条 `execute` 都会抛错并被同样吞掉** —— 结果是该失败语句之后的所有迁移被连锁跳过，插件新增字段始终无法落库（需手动 `ALTER` 或清库重建）。

PostgreSQL 下尤为明显（aborted 事务会拒绝后续所有命令直到 rollback）。

## 修复

失败时 `await session.rollback()` 复位会话，使每条迁移相互独立；并把吞掉的异常降级为 `debug` 日志便于排查；`except:` 收紧为 `except Exception`（避免误吞 `CancelledError` / `KeyboardInterrupt`）。

## 验证

sqlite 下：删除某表两列后重启核心，迁移在 `trans_adapter` 阶段自动补回；修复前同样场景下两列不会被补回。
