### PR TITLE
🐛 修复残留 .part 临时文件导致启动时 FileExistsError 崩溃

### DIFF
--- a/gsuid_core/config.py
+++ b/gsuid_core/config.py
@@ -160,6 +160,7 @@ class CoreConfig:
                     str(CONFIG_PATH),
                     text_mode=False,
                     overwrite=True,
+                    overwrite_part=True,
                     file_perms=0o644,
                 ) as file:
                     if file:
@@ -345,6 +346,7 @@ class PluginConfigStore:
                     str(target),
                     text_mode=False,
                     overwrite=True,
+                    overwrite_part=True,
                     file_perms=0o644,
                 ) as file:
                     if file:

--- a/gsuid_core/utils/plugins_config/gs_config.py
+++ b/gsuid_core/utils/plugins_config/gs_config.py
@@ -262,6 +262,7 @@ class StringConfig:
             str(self.CONFIG_PATH),
             text_mode=False,
             overwrite=True,
+            overwrite_part=True,
             file_perms=0o644,
         ) as file:
             if file:

--- a/gsuid_core/webconsole/brand_api.py
+++ b/gsuid_core/webconsole/brand_api.py
@@ -120,6 +120,7 @@ def _write_brand_config(data: Dict[str, Any]) -> bool:
             str(BRAND_CONFIG_PATH),
             text_mode=False,
             overwrite=True,
+            overwrite_part=True,
             file_perms=0o644,
         ) as file:
             if not file:
@@ -270,6 +271,7 @@ async def upload_brand_icon(
             str(BRAND_ICON_PATH),
             text_mode=False,
             overwrite=True,
+            overwrite_part=True,
             file_perms=0o644,
         ) as file:
             if not file:

--- a/gsuid_core/webconsole/live_chat_api.py
+++ b/gsuid_core/webconsole/live_chat_api.py
@@ -135,9 +135,7 @@ def _ensure_dirs() -> None:
 @to_thread
 def _atomic_write_json(path: Path, data: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with atomic_save(
-        str(path), text_mode=True, file_perms=None, overwrite=True, overwrite_part=True
-    ) as f:
+    with atomic_save(str(path), text_mode=True, file_perms=None, overwrite=True, overwrite_part=True) as f:
         # boltons.atomic_save 注解可能为 Optional；None 时不可 dump
         if f is None:
             raise RuntimeError(f"atomic_save returned None for {path}")

--- a/gsuid_core/webconsole/live_chat_api.py
+++ b/gsuid_core/webconsole/live_chat_api.py
@@ -135,7 +135,9 @@ def _ensure_dirs() -> None:
 @to_thread
 def _atomic_write_json(path: Path, data: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with atomic_save(str(path), text_mode=True, file_perms=None, overwrite=True) as f:
+    with atomic_save(
+        str(path), text_mode=True, file_perms=None, overwrite=True, overwrite_part=True
+    ) as f:
         # boltons.atomic_save 注解可能为 Optional；None 时不可 dump
         if f is None:
             raise RuntimeError(f"atomic_save returned None for {path}")

--- a/gsuid_core/webconsole/session_store.py
+++ b/gsuid_core/webconsole/session_store.py
@@ -123,6 +123,7 @@ class SessionStore:
                 str(WEB_SESSIONS_PATH),
                 text_mode=False,
                 overwrite=True,
+                overwrite_part=True,
                 file_perms=0o600,
             ) as f:
                 if f:


### PR DESCRIPTION
## 问题

进程在写配置文件的瞬间被杀（Windows 上强杀很常见）时，`boltons.atomic_save` 会残留 `xxx.json.part` 临时文件。由于 `atomic_save` 默认**不覆盖**已存在的 part 文件（`O_EXCL` 独占创建），下次启动写配置时直接抛出 `FileExistsError`，且**每次启动都会在同一处崩溃**，用户不手动删文件核心就永远起不来。

实际堆栈（Windows，Python 3.14）：

```
FileExistsError: [Errno 17] File exists: '...\data\ai_core\tavily_config.json.part'
  at gsuid_core/utils/plugins_config/gs_config.py:261 in write_config
  at gsuid_core/utils/plugins_config/gs_config.py:258 in sort_config
  ...
```

## 修复

给全部 **7 处** `atomic_save` 调用统一加上 `overwrite_part=True`：

- `gsuid_core/config.py`（2 处）
- `gsuid_core/utils/plugins_config/gs_config.py`（1 处）
- `gsuid_core/webconsole/brand_api.py`（2 处）
- `gsuid_core/webconsole/live_chat_api.py`（1 处）
- `gsuid_core/webconsole/session_store.py`（1 处）

part 文件残留只可能是上次异常退出的产物（同一进程内写同一配置不会并发），覆盖它是安全的；这也与 `overwrite=True` 覆盖目标文件的既有语义一致。

## 验证

```python
# 模拟残留 part 文件
Path('cfg.json.part').write_text('stale')
# 修复前：FileExistsError（已复现）
# 修复后：正常写入 {'ok': 1}（已通过）
```

已在本机 venv 中分别验证修复前复现崩溃、修复后正常写入。