### PR TITLE
🐛 修复重载与卸载插件时帮助图缓存未清理的问题

### DIFF
--- a/gsuid_core/help/utils.py
+++ b/gsuid_core/help/utils.py
@@ -30,3 +30,28 @@ def register_help(
     }
     if plugin_help not in plugins_help["插件帮助一览"]["data"]:
         plugins_help["插件帮助一览"]["data"].append(plugin_help)
+
+
+def clean_plugin_help(plugin_name: str) -> None:
+    """清理指定插件的帮助缓存与一览条目，并使 GsCore 主帮助图失效。"""
+    from gsuid_core.data_store import get_res_path
+    from gsuid_core.help.draw_new_plugin_help import cache as new_cache
+    from gsuid_core.help.draw_plugin_help import cache as old_cache
+
+    # 清理内存 cache 标记（含自身与 GsCore 主帮助）
+    new_cache.pop(plugin_name, None)
+    new_cache.pop("GsCore", None)
+    old_cache.pop(plugin_name, None)
+    old_cache.pop("GsCore", None)
+
+    # 剔除一览表中的注册条目
+    category = plugins_help.get("插件帮助一览")
+    if category is not None:
+        category["data"] = [item for item in category["data"] if item["name"] != plugin_name]
+
+    # 删除磁盘上的过期帮助图
+    help_dir = get_res_path("help")
+    for pattern in (f"{plugin_name}_*.jpg", f"{plugin_name}.jpg", "GsCore_*.jpg", "GsCore.jpg"):
+        for file in help_dir.glob(pattern):
+            if file.is_file():
+                file.unlink(missing_ok=True)

--- a/gsuid_core/help/utils.py
+++ b/gsuid_core/help/utils.py
@@ -35,8 +35,8 @@ def register_help(
 def clean_plugin_help(plugin_name: str) -> None:
     """清理指定插件的帮助缓存与一览条目，并使 GsCore 主帮助图失效。"""
     from gsuid_core.data_store import get_res_path
-    from gsuid_core.help.draw_new_plugin_help import cache as new_cache
     from gsuid_core.help.draw_plugin_help import cache as old_cache
+    from gsuid_core.help.draw_new_plugin_help import cache as new_cache
 
     # 清理内存 cache 标记（含自身与 GsCore 主帮助）
     new_cache.pop(plugin_name, None)

--- a/gsuid_core/locales/en/plugin.json
+++ b/gsuid_core/locales/en/plugin.json
@@ -40,6 +40,7 @@
   "log.plugin.gscore_cleanup_agent_hooks_tools": "[GsCore] Cleaned {hooks} agent hooks and {tools} AI tools for {plugin_name}",
   "log.plugin.gscore_cleanup_global_registration_start": "[GsCore] Starting cleanup of global registration state for plugin {plugin_name}...",
   "log.plugin.gscore_fail_agent_hooks": "[GsCore] Failed to clean agent hooks / kit slots for {plugin_name}: {e}",
+  "log.plugin.gscore_fail_help_cache": "[GsCore] Exception while cleaning help cache and registration for plugin {plugin_name}: {e}",
   "log.plugin.gscore_fail_lifecycle_hooks": "[GsCore] Exception while clearing lifecycle Hooks for plugin {plugin_name}: {e}",
   "log.plugin.gscore_fail_running_startup_hook": "[GsCore] Exception while running startup Hook {p0} for plugin {plugin_name}: {res}",
   "log.plugin.gscore_fail_web_routes": "[GsCore] Exception while clearing web routes for plugin {plugin_name}: {e}",

--- a/gsuid_core/locales/ja/plugin.json
+++ b/gsuid_core/locales/ja/plugin.json
@@ -40,6 +40,7 @@
   "log.plugin.gscore_cleanup_agent_hooks_tools": "[GsCore] {plugin_name} の Agent フック {hooks} 件 / AI ツール {tools} 個を整理しました",
   "log.plugin.gscore_cleanup_global_registration_start": "[GsCore] プラグイン {plugin_name} のグローバル登録状態のクリーンアップを開始...",
   "log.plugin.gscore_fail_agent_hooks": "[GsCore] {plugin_name} の Agent フック / キットスロットの整理に失敗: {e}",
+  "log.plugin.gscore_fail_help_cache": "[GsCore] プラグイン {plugin_name} のヘルプキャッシュと登録のクリア中に例外が発生: {e}",
   "log.plugin.gscore_fail_lifecycle_hooks": "[GsCore] プラグイン {plugin_name} のライフサイクル Hook のクリア中に例外が発生: {e}",
   "log.plugin.gscore_fail_running_startup_hook": "[GsCore] プラグイン {plugin_name} の起動 Hook {p0} の実行中に例外が発生: {res}",
   "log.plugin.gscore_fail_web_routes": "[GsCore] プラグイン {plugin_name} の web ルートのクリア中に例外が発生: {e}",

--- a/gsuid_core/locales/zh-cn/plugin.json
+++ b/gsuid_core/locales/zh-cn/plugin.json
@@ -40,6 +40,7 @@
   "log.plugin.gscore_cleanup_agent_hooks_tools": "[GsCore] 已清理 {plugin_name} 的 Agent 环 hook {hooks} 条 / AI 工具 {tools} 个",
   "log.plugin.gscore_cleanup_global_registration_start": "[GsCore] 开始清理插件 {plugin_name} 的全局注册状态...",
   "log.plugin.gscore_fail_agent_hooks": "[GsCore] 清理 {plugin_name} 的 Agent 环 hook / 套件槽失败: {e}",
+  "log.plugin.gscore_fail_help_cache": "[GsCore] 清理插件 {plugin_name} 的帮助缓存与一览注册时异常: {e}",
   "log.plugin.gscore_fail_lifecycle_hooks": "[GsCore] 清理插件 {plugin_name} 的生命周期 Hook 时异常: {e}",
   "log.plugin.gscore_fail_running_startup_hook": "[GsCore] 插件 {plugin_name} 启动 Hook {p0} 执行异常: {res}",
   "log.plugin.gscore_fail_web_routes": "[GsCore] 清理插件 {plugin_name} 的 web 路由时异常: {e}",

--- a/gsuid_core/utils/plugins_update/_plugins.py
+++ b/gsuid_core/utils/plugins_update/_plugins.py
@@ -265,6 +265,14 @@ async def uninstall_plugin(path: Path):
         unregister_meta_plugin(name)
         logger.warning(t("log.plugin.uninstall_meta_warn", plugin_name=name))
         warn = f"⚠️ 已卸载基础设施插件 {name}，依赖它的插件下次调用会失败。\n"
+
+    try:
+        from gsuid_core.help.utils import clean_plugin_help
+
+        clean_plugin_help(name)
+    except Exception as e:
+        logger.warning(t("log.plugin.gscore_fail_help_cache", plugin_name=name, e=e))
+
     kind = "目录" if was_dir else "文件"
     return f"{warn}✅ 插件{kind} {name} 删除成功!"
 

--- a/gsuid_core/utils/plugins_update/reload_plugin.py
+++ b/gsuid_core/utils/plugins_update/reload_plugin.py
@@ -161,6 +161,14 @@ def _clean_plugin_global_state(plugin_name: str) -> None:
     # ④ Agent 环 hook + 套件槽 + AI 工具注册表
     _clean_plugin_agent_state(plugin_name)
 
+    # ⑤ 帮助图缓存与一览注册条目
+    try:
+        from gsuid_core.help.utils import clean_plugin_help
+
+        clean_plugin_help(plugin_name)
+    except Exception as e:
+        logger.warning(i18n_t("log.plugin.gscore_fail_help_cache", plugin_name=plugin_name, e=e))
+
 
 def _clean_plugin_agent_state(plugin_name: str) -> None:
     """摘掉插件的 Agent 环 hook、让它占用的槽位回落默认套件、卸掉它注册的 AI 工具。


### PR DESCRIPTION
### 1. 背景与问题
在动态重载 (`reload_plugin`) 或卸载 (`uninstall_plugin`) 插件时，原有机制未清理帮助系统相关的内存注册信息与磁盘图片缓存，导致以下问题：
- **卸载插件后**：主帮助图（GsCore 帮助）或帮助一览中仍残留已卸载插件的信息，或继续返回旧的磁盘缓存图。
- **重载插件后**：若插件更新了帮助文案/指令，由于命中未失效的内存标记或磁盘缓存文件，用户查询帮助时依然返回旧图。

---

### 2. 主要变更
- **新增 `clean_plugin_help(plugin_name)`** ([gsuid_core/help/utils.py](file:///d:/gsuid_core/gsuid_core/help/utils.py))：
  - **内存缓存清理**：重置新旧帮助渲染模块中的内存 cache 标记（含目标插件自身及 `GsCore` 主帮助）。
  - **帮助一览清理**：从 `plugins_help["插件帮助一览"]` 列表中剔除已卸载/待重载插件的条目。
  - **磁盘缓存清理**：自动删除 `data/help/` 下对应的 `{plugin_name}_*.jpg`、`{plugin_name}.jpg` 以及 `GsCore_*.jpg`、`GsCore.jpg` 缓存文件。
- **接入插件清理生命周期**：
  - 在 `reload_plugin._clean_plugin_global_state` 中接入帮助状态清理。
  - 在 `_plugins.uninstall_plugin` 中接入帮助状态清理。
- **国际化日志支持**：
  - 在 `en` / `ja` / `zh-cn` 的 `plugin.json` 中补充 `log.plugin.gscore_fail_help_cache` 错误日志键值。